### PR TITLE
[WU-07] T-06 LLM 계정 API (API Key/OAuth/목록/삭제) 구현

### DIFF
--- a/docs/sessions/2026-03-03-T-06.md
+++ b/docs/sessions/2026-03-03-T-06.md
@@ -94,3 +94,20 @@ Use `docs/templates/commit-message.template.md`.
   - T-07.
 - Suggested first check for next session:
   - analyzer 체인(rule -> llm -> fallback) 시작 전에 `LlmAccountService`에서 provider/model 선택 인터페이스를 분리할지 검토.
+
+## 9. PR Review Follow-up (PR #21)
+- Reason:
+  - 자동 리뷰에서 OAuth state 누적 가능성, callback 파라미터 누락/공백 경계값, `base_url` 스킴 검증 보강 제안이 제기됨.
+- Changes:
+  - `LlmAccountService`에 OAuth state TTL(10분)과 opportunistic purge 로직을 추가.
+  - `callbackOAuth`에서 state 만료/재사용을 `Invalid or expired oauth state`로 일관 처리.
+  - `validateBaseUrl`에서 `http/https` 스킴만 허용하도록 검증 강화.
+  - `LlmAccountController`의 callback query param(`code`, `state`)을 `required=false`로 변경해 누락 시에도 표준 `ErrorResponse` 경로로 처리.
+  - 테스트 보강:
+    - `LlmAccountEndpointsContractTest`: callback `code/state` 공백 400, query param 누락 400
+    - `LlmAccountServiceTest`: OAuth state 재사용 409, `ftp://` 스킴 거부
+- Re-run verification:
+  - `./gradlew test --tests "*LlmAccount*Test"` => PASS
+  - `./gradlew test --tests "*ProjectEndpointsContractTest" --tests "*LokiConnectorEndpointsContractTest" --tests "*IngestEndpointsContractTest" --tests "*IncidentEndpointsContractTest" --tests "*LlmAccountEndpointsContractTest"` => PASS
+  - `./gradlew check` => PASS
+  - `./gradlew test` => PASS

--- a/src/main/java/com/logcopilot/llm/LlmAccountController.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountController.java
@@ -74,8 +74,8 @@ public class LlmAccountController {
 	public OAuthCallbackResponse callbackLlmOAuth(
 		@PathVariable("project_id") String projectId,
 		@PathVariable("provider") String provider,
-		@RequestParam("code") String code,
-		@RequestParam("state") String state
+		@RequestParam(value = "code", required = false) String code,
+		@RequestParam(value = "state", required = false) String state
 	) {
 		LlmAccountService.OAuthCallbackResult result = llmAccountService.callbackOAuth(
 			projectId,

--- a/src/main/java/com/logcopilot/llm/LlmAccountService.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -20,6 +21,7 @@ import java.util.UUID;
 @Service
 public class LlmAccountService {
 
+	private static final Duration OAUTH_STATE_TTL = Duration.ofMinutes(10);
 	private final ProjectService projectService;
 	private final Map<String, LinkedHashMap<String, AccountState>> accountsByProject = new HashMap<>();
 	private final Map<String, Map<String, String>> apiKeyAccountIdByProjectProvider = new HashMap<>();
@@ -93,6 +95,7 @@ public class LlmAccountService {
 	public synchronized OAuthStartResult startOAuth(String projectId, String providerInput) {
 		requireProjectForScopedRequest(projectId);
 		String provider = validateProviderForBadRequest(providerInput);
+		purgeExpiredOAuthStates();
 
 		String state = UUID.randomUUID().toString();
 		oauthStateByValue.put(state, new OAuthState(projectId, provider, Instant.now()));
@@ -111,11 +114,18 @@ public class LlmAccountService {
 		String provider = validateProviderForBadRequest(providerInput);
 		validateCode(code);
 		validateState(state);
+		purgeExpiredOAuthStates();
+		Instant now = Instant.now();
 
 		OAuthState started = oauthStateByValue.get(state);
-		if (started == null
-			|| !started.projectId().equals(projectId)
-			|| !started.provider().equals(provider)) {
+		if (started == null) {
+			throw new ConflictException("Invalid or expired oauth state");
+		}
+		if (isExpired(started, now)) {
+			oauthStateByValue.remove(state);
+			throw new ConflictException("Invalid or expired oauth state");
+		}
+		if (!started.projectId().equals(projectId) || !started.provider().equals(provider)) {
 			throw new ConflictException("Invalid or expired oauth state");
 		}
 		oauthStateByValue.remove(state);
@@ -268,10 +278,23 @@ public class LlmAccountService {
 			if (!uri.isAbsolute() || uri.getHost() == null) {
 				throw new ValidationException("base_url must be a valid URI");
 			}
+			String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+			if (!"http".equals(scheme) && !"https".equals(scheme)) {
+				throw new ValidationException("base_url must be a valid URI");
+			}
 		} catch (URISyntaxException exception) {
 			throw new ValidationException("base_url must be a valid URI");
 		}
 		return trimmed;
+	}
+
+	private void purgeExpiredOAuthStates() {
+		Instant now = Instant.now();
+		oauthStateByValue.entrySet().removeIf(entry -> isExpired(entry.getValue(), now));
+	}
+
+	private boolean isExpired(OAuthState state, Instant now) {
+		return state.createdAt().isBefore(now.minus(OAUTH_STATE_TTL));
 	}
 
 	private void validateCode(String code) {

--- a/src/test/java/com/logcopilot/llm/LlmAccountEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmAccountEndpointsContractTest.java
@@ -170,6 +170,54 @@ class LlmAccountEndpointsContractTest {
 	}
 
 	@Test
+	@DisplayName("GET /v1/projects/{project_id}/llm-oauth/{provider}/callback 은 code/state 공백 시 400을 반환한다")
+	void callbackLlmOAuthReturns400WhenCodeOrStateBlank() throws Exception {
+		String projectId = createProjectId("llm-oauth-callback-blank");
+		MvcResult started = mockMvc.perform(post("/v1/projects/{project_id}/llm-oauth/{provider}/start", projectId, "openai")
+				.header("Authorization", "Bearer llm-token"))
+			.andExpect(status().isOk())
+			.andReturn();
+		String state = jsonValue(started, "/data/state");
+
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", projectId, "openai")
+				.queryParam("code", " ")
+				.queryParam("state", state))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("bad_request"))
+			.andExpect(jsonPath("$.error.message").value("code must not be blank"));
+
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", projectId, "openai")
+				.queryParam("code", "oauth-code-1")
+				.queryParam("state", " "))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("bad_request"))
+			.andExpect(jsonPath("$.error.message").value("state must not be blank"));
+	}
+
+	@Test
+	@DisplayName("GET /v1/projects/{project_id}/llm-oauth/{provider}/callback 은 query param 누락 시 400 표준 에러를 반환한다")
+	void callbackLlmOAuthReturns400WithStandardErrorWhenQueryParamMissing() throws Exception {
+		String projectId = createProjectId("llm-oauth-callback-missing");
+		MvcResult started = mockMvc.perform(post("/v1/projects/{project_id}/llm-oauth/{provider}/start", projectId, "openai")
+				.header("Authorization", "Bearer llm-token"))
+			.andExpect(status().isOk())
+			.andReturn();
+		String state = jsonValue(started, "/data/state");
+
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", projectId, "openai")
+				.queryParam("state", state))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("bad_request"))
+			.andExpect(jsonPath("$.error.message").value("code must not be blank"));
+
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", projectId, "openai")
+				.queryParam("code", "oauth-code-1"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("bad_request"))
+			.andExpect(jsonPath("$.error.message").value("state must not be blank"));
+	}
+
+	@Test
 	@DisplayName("GET /v1/projects/{project_id}/llm-accounts 는 계정 목록을 반환한다")
 	void listLlmAccountsReturnsAccountList() throws Exception {
 		String projectId = createProjectId("llm-list");

--- a/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
@@ -90,6 +90,24 @@ class LlmAccountServiceTest {
 	}
 
 	@Test
+	@DisplayName("LlmAccountService는 사용된 OAuth state를 재사용하면 ConflictException을 던진다")
+	void callbackOAuthRejectsReusedState() {
+		ProjectDto project = projectService.create("oauth-reuse-project", "prod");
+		LlmAccountService.OAuthStartResult start = llmAccountService.startOAuth(project.id(), "openai");
+
+		llmAccountService.callbackOAuth(project.id(), "openai", "oauth-code-1", start.state());
+
+		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
+			project.id(),
+			"openai",
+			"oauth-code-2",
+			start.state()
+		))
+			.isInstanceOf(ConflictException.class)
+			.hasMessage("Invalid or expired oauth state");
+	}
+
+	@Test
 	@DisplayName("LlmAccountService는 존재하지 않는 프로젝트 조회 시 NotFoundException을 던진다")
 	void listThrowsNotFoundWhenProjectMissing() {
 		assertThatThrownBy(() -> llmAccountService.list("missing-project"))
@@ -177,6 +195,25 @@ class LlmAccountServiceTest {
 				"sk-1",
 				"gpt-4o-mini",
 				"not-a-uri"
+			)
+		))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("base_url must be a valid URI");
+	}
+
+	@Test
+	@DisplayName("LlmAccountService는 API key 요청의 base_url 스킴이 http/https가 아니면 ValidationException을 던진다")
+	void upsertApiKeyThrowsWhenBaseUrlSchemeUnsupported() {
+		ProjectDto project = projectService.create("uri-scheme-project", "prod");
+
+		assertThatThrownBy(() -> llmAccountService.upsertApiKey(
+			project.id(),
+			new LlmAccountService.ApiKeyUpsertCommand(
+				"openai",
+				"main",
+				"sk-1",
+				"gpt-4o-mini",
+				"ftp://api.openai.com/v1"
 			)
 		))
 			.isInstanceOf(ValidationException.class)


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - T-06 범위의 LLM 계정 API(`api-key upsert`, `OAuth start/callback`, `list`, `delete`)를 구현했습니다.
  - LLM 계정 서비스와 계약/단위 테스트를 추가하고, T-06 세션 노트를 작성했습니다.
- 왜 필요한가:
  - MVP 스펙의 OpenAI/Gemini 계정 관리 기능을 계약 기준으로 제공하기 위해 필요합니다.

## 연결 이슈
- Closes #20

## 범위 점검
- 포함:
  - `/v1/projects/{project_id}/llm-accounts/api-key`
  - `/v1/projects/{project_id}/llm-oauth/{provider}/start`
  - `/v1/projects/{project_id}/llm-oauth/{provider}/callback`
  - `/v1/projects/{project_id}/llm-accounts`
  - `/v1/projects/{project_id}/llm-accounts/{account_id}`
  - LLM 계정 통합/단위 테스트 및 세션 노트
- 제외:
  - 외부 OAuth provider 실제 토큰 교환/갱신
  - analyzer 체인(T-07), 정책/알림(T-08/T-09)

## 주요 변경 사항
- `LlmAccountController` 추가로 T-06 엔드포인트 계약 구현.
- `LlmAccountService` 추가로 provider 검증, API key upsert(201/200), OAuth state 검증(409), project 경계 검증(400/404) 구현.
- `LlmAccountEndpointsContractTest`/`LlmAccountServiceTest` 추가 및 회귀 테스트 통과.

## TDD 근거
- RED:
  - `./gradlew test --tests "*LlmAccount*Test"` 실행 시 `LlmAccountService` 미구현으로 `compileTestJava` 실패(13 errors).
- GREEN:
  - `./gradlew test --tests "*LlmAccount*Test"` PASS
  - `./gradlew test --tests "*LlmAccountEndpointsContractTest"` PASS
- REFACTOR:
  - provider 검증 흐름을 400/422로 분리하고, OAuth state 처리 및 project 경계 검증을 정리.

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: N/A (의존성/설정/멀티모듈 영향 없음)

## Rule-Base 근거
- AC1 -> `./gradlew test --tests "*LlmAccountEndpointsContractTest"` -> PASS
- AC2 -> `./gradlew test --tests "*LlmAccountEndpointsContractTest"` -> PASS
- AC3 -> `./gradlew test --tests "*LlmAccountEndpointsContractTest"` -> PASS
- AC4 -> `./gradlew check && ./gradlew test` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 신규 PR 생성 전 (없음)
- codex:
  - 생성/연동 경로의 project 검증 누락 가능성 점검 후 400 검증으로 보강

## 리스크 / 롤백
- 확인된 리스크:
  - OAuth state TTL/만료 정책 미구현
  - API key 저장은 in-memory 임시 구현
- 롤백 계획:
  - 해당 커밋 revert로 T-05 상태 복원 가능

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-07에서 analyzer 체인(rule -> llm -> fallback)과 계정 선택 전략 연동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * LLM 계정 관리 API 추가: API 키 및 OAuth 기반 인증 지원
  * 프로젝트별 LLM 계정의 추가, 수정, 조회, 삭제 기능 제공
  * 여러 LLM 제공자의 계정 관리 및 전환 지원

* **테스트**
  * LLM 계정 관리 기능의 포괄적 계약 테스트 및 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->