### PR TITLE
[WU-10] T-09 Alert 채널 API + Audit 로그 조회 구현

### DIFF
--- a/docs/sessions/2026-03-03-T-09.md
+++ b/docs/sessions/2026-03-03-T-09.md
@@ -84,3 +84,16 @@ Use `docs/templates/commit-message.template.md`.
   - T-10.
 - Suggested first check for next session:
   - 신뢰성 하드닝에서 Alert/Audit 영속화 전략 및 build 게이트 필요 여부를 먼저 확정할 것.
+
+## 9. PR Review Follow-up (PR #27)
+- Reason:
+  - 리뷰에서 audit metadata의 이메일 원문 노출, actor 해시의 기본 문자셋 의존, 마스킹 회귀 테스트 누락이 지적됨.
+- Changes:
+  - `AlertService` email audit metadata의 `from` 값을 원문 대신 `domain:<domain>` 형식으로 최소화 저장.
+  - `AlertService` actor 해시 계산 시 `getBytes(StandardCharsets.UTF_8)`로 고정.
+  - `AlertEndpointsContractTest`에 actor 마스킹(`token:` prefix, 원본 토큰 비포함) 단정 추가.
+  - `AlertServiceTest`에 email audit metadata 마스킹 단정 추가.
+- Re-run verification:
+  - `./gradlew test --tests "*Alert*Test"` => PASS
+  - `./gradlew test` => PASS
+  - `./gradlew check` => PASS

--- a/docs/sessions/2026-03-03-T-09.md
+++ b/docs/sessions/2026-03-03-T-09.md
@@ -1,0 +1,86 @@
+# Session Task Note - T-09
+
+## Metadata
+- Date: 2026-03-03
+- Issue: #26
+- Branch: `feature/26-t09-alert-audit-apis`
+- Task ID: T-09
+- Related spec: `docs/specs/2026-03-03-mvp-v1-work-unit-bootstrap.md`
+
+## 1. Intent Check
+- Do now:
+  - OpenAPI 계약 기준으로 Alert API 2개(`slack`, `email`)와 Audit 로그 조회 API를 구현한다.
+  - Alert 설정 생성/갱신(201/200), 인증 실패(401), 검증 실패(422), 조회 실패(404) 경로를 테스트로 보장한다.
+- Do not do now:
+  - 실제 Slack webhook 호출 및 SMTP 발송 연동.
+  - 영속 저장소 기반 audit 보존/검색 고도화.
+- Done means:
+  - `POST /v1/projects/{project_id}/alerts/slack` / `POST /v1/projects/{project_id}/alerts/email`가 생성/갱신 상태 코드를 올바르게 반환한다.
+  - `GET /v1/projects/{project_id}/audit-logs`가 action/actor/cursor/limit 필터와 `meta.request_id`, `meta.next_cursor`를 반환한다.
+  - Alert/Audit 경로의 표준 에러 응답(`ErrorResponse`)이 계약대로 동작한다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction` -> `openapi` -> `architecture-guardrails` -> workflow 문서 순으로 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - In scope의 "Slack/Email alert configuration" 및 "audit logs" 항목에 해당.
+- AC-to-rule mapping to execute:
+  - AC1(alert channel 설정) -> Integration -> `./gradlew test --tests "*AlertEndpointsContractTest"` -> PASS
+  - AC2(audit 조회/필터/페이징) -> Unit/Integration -> `./gradlew test --tests "*Alert*Test"` -> PASS
+  - AC3(필수 게이트) -> Build/Test -> `./gradlew test && ./gradlew check` -> PASS
+
+## 2. Plan (Short)
+1. Alert/Audit 계약/단위 테스트를 먼저 추가하고 RED 실패를 확인한다.
+2. `AlertService`/`AlertController`를 최소 구현해 계약을 만족한다.
+3. 전체 테스트/게이트 실행 후 세션 노트에 TDD/검증 근거를 기록한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java`
+  - `src/test/java/com/logcopilot/alert/AlertServiceTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*Alert*Test"` 실행 시 `AlertService` 미구현으로 `compileTestJava` 실패(26 errors).
+- GREEN pass output summary:
+  - `./gradlew test --tests "*Alert*Test"` PASS
+  - `./gradlew test && ./gradlew check` PASS
+- REFACTOR summary:
+  - Alert upsert 로직을 공통화(`upsertChannel`)해 Slack/Email 분기 중복을 제거했다.
+  - Audit actor는 토큰 원문 대신 SHA-256 해시 prefix(`token:xxxxxxxxxxxx`)로 저장해 민감정보 노출을 줄였다.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/alert/AlertController.java`
+  - `src/main/java/com/logcopilot/alert/AlertService.java`
+  - `src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java`
+  - `src/test/java/com/logcopilot/alert/AlertServiceTest.java`
+- Why this approach:
+  - 기존 코드베이스 패턴(thin controller + service validation)을 유지해 회귀 위험을 낮췄다.
+  - Audit 로그는 프로젝트 스코프 append-only 리스트로 저장해 guardrail(append-only, project-scoped)을 만족시켰다.
+  - OpenAPI의 Alert/Audit 계약 필드(snake_case, response shape)에 맞춰 응답 DTO를 분리했다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*Alert*Test"`
+  - `./gradlew test && ./gradlew check`
+- Results:
+  - RED 1회 실패 확인 후 GREEN/회귀/필수 게이트 모두 PASS.
+  - `./gradlew build`는 의존성/설정/멀티모듈 영향이 없어 이번 태스크에서 생략.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Self-review (OpenAPI 계약 + guardrail + 에러 스키마 확인).
+- Findings:
+  - Alert/Audit 저장소가 in-memory이므로 프로세스 재시작 시 설정/로그가 유실된다.
+  - actor는 해시 토큰 기반 식별자라 실제 사용자 식별 체계와 일치하지 않는다.
+- Resolution:
+  - T-09 범위에서는 계약/API 동작 보장을 우선하고, 영속화/실사용자 매핑은 하드닝 태스크(T-10)에서 보강한다.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - SMTP/Slack 민감정보는 현재 in-memory 저장이며 운영 수준 암호화 저장이 필요하다.
+  - Audit cursor는 정수 오프셋 기반이라 대량 데이터 환경에서 안정적 snapshot paging이 필요하다.
+- Next task ID:
+  - T-10.
+- Suggested first check for next session:
+  - 신뢰성 하드닝에서 Alert/Audit 영속화 전략 및 build 게이트 필요 여부를 먼저 확정할 것.

--- a/src/main/java/com/logcopilot/alert/AlertController.java
+++ b/src/main/java/com/logcopilot/alert/AlertController.java
@@ -1,0 +1,190 @@
+package com.logcopilot.alert;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.logcopilot.common.api.ApiMeta;
+import com.logcopilot.common.auth.BearerTokenValidator;
+import com.logcopilot.common.error.ValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/projects/{project_id}")
+public class AlertController {
+
+	private final AlertService alertService;
+	private final BearerTokenValidator bearerTokenValidator;
+
+	public AlertController(
+		AlertService alertService,
+		BearerTokenValidator bearerTokenValidator
+	) {
+		this.alertService = alertService;
+		this.bearerTokenValidator = bearerTokenValidator;
+	}
+
+	@PostMapping("/alerts/slack")
+	public ResponseEntity<AlertChannelResponse> configureSlack(
+		@PathVariable("project_id") String projectId,
+		@RequestHeader(value = "Authorization", required = false) String authorization,
+		@RequestBody(required = false) SlackAlertRequest request
+	) {
+		String actorToken = bearerTokenValidator.validate(authorization);
+		if (request == null) {
+			throw new ValidationException("Request body must not be null");
+		}
+
+		AlertService.ConfigureResult result = alertService.configureSlack(
+			projectId,
+			actorToken,
+			new AlertService.ConfigureSlackCommand(
+				request.webhookUrl(),
+				request.channel(),
+				request.minConfidence()
+			)
+		);
+		return toResponse(result);
+	}
+
+	@PostMapping("/alerts/email")
+	public ResponseEntity<AlertChannelResponse> configureEmail(
+		@PathVariable("project_id") String projectId,
+		@RequestHeader(value = "Authorization", required = false) String authorization,
+		@RequestBody(required = false) EmailAlertRequest request
+	) {
+		String actorToken = bearerTokenValidator.validate(authorization);
+		if (request == null) {
+			throw new ValidationException("Request body must not be null");
+		}
+
+		AlertService.ConfigureResult result = alertService.configureEmail(
+			projectId,
+			actorToken,
+			new AlertService.ConfigureEmailCommand(
+				request.from(),
+				request.recipients(),
+				request.smtp() == null
+					? null
+					: new AlertService.SmtpCommand(
+						request.smtp().host(),
+						request.smtp().port(),
+						request.smtp().username(),
+						request.smtp().password(),
+						request.smtp().starttls()
+					),
+				request.minConfidence()
+			)
+		);
+		return toResponse(result);
+	}
+
+	@GetMapping("/audit-logs")
+	public AuditLogListResponse listAuditLogs(
+		@PathVariable("project_id") String projectId,
+		@RequestHeader(value = "Authorization", required = false) String authorization,
+		@RequestParam(value = "action", required = false) String action,
+		@RequestParam(value = "actor", required = false) String actor,
+		@RequestParam(value = "cursor", required = false) String cursor,
+		@RequestParam(value = "limit", required = false) Integer limit
+	) {
+		bearerTokenValidator.validate(authorization);
+
+		AlertService.AuditLogListResult result = alertService.listAuditLogs(
+			projectId,
+			new AlertService.AuditLogQuery(action, actor, cursor, limit)
+		);
+		List<AuditLogData> data = result.data().stream()
+			.map(log -> new AuditLogData(
+				log.id(),
+				log.actor(),
+				log.action(),
+				log.resourceType(),
+				log.resourceId(),
+				log.createdAt(),
+				log.metadata()
+			))
+			.toList();
+		return new AuditLogListResponse(data, new ApiMeta(result.requestId(), result.nextCursor()));
+	}
+
+	private ResponseEntity<AlertChannelResponse> toResponse(AlertService.ConfigureResult result) {
+		HttpStatus status = result.created() ? HttpStatus.CREATED : HttpStatus.OK;
+		AlertService.AlertChannel channel = result.channel();
+		return ResponseEntity.status(status).body(new AlertChannelResponse(new AlertChannelData(
+			channel.id(),
+			channel.type(),
+			channel.enabled(),
+			channel.updatedAt()
+		)));
+	}
+
+	public record SlackAlertRequest(
+		@JsonProperty("webhook_url")
+		String webhookUrl,
+		String channel,
+		@JsonProperty("min_confidence")
+		Double minConfidence
+	) {
+	}
+
+	public record EmailAlertRequest(
+		String from,
+		List<String> recipients,
+		SmtpRequest smtp,
+		@JsonProperty("min_confidence")
+		Double minConfidence
+	) {
+	}
+
+	public record SmtpRequest(
+		String host,
+		Integer port,
+		String username,
+		String password,
+		Boolean starttls
+	) {
+	}
+
+	public record AlertChannelResponse(AlertChannelData data) {
+	}
+
+	public record AlertChannelData(
+		String id,
+		String type,
+		boolean enabled,
+		@JsonProperty("updated_at")
+		Instant updatedAt
+	) {
+	}
+
+	public record AuditLogListResponse(
+		List<AuditLogData> data,
+		ApiMeta meta
+	) {
+	}
+
+	public record AuditLogData(
+		String id,
+		String actor,
+		String action,
+		@JsonProperty("resource_type")
+		String resourceType,
+		@JsonProperty("resource_id")
+		String resourceId,
+		@JsonProperty("created_at")
+		Instant createdAt,
+		Map<String, Object> metadata
+	) {
+	}
+}

--- a/src/main/java/com/logcopilot/alert/AlertService.java
+++ b/src/main/java/com/logcopilot/alert/AlertService.java
@@ -1,0 +1,429 @@
+package com.logcopilot.alert;
+
+import com.logcopilot.common.error.NotFoundException;
+import com.logcopilot.common.error.ValidationException;
+import com.logcopilot.project.ProjectService;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Service
+public class AlertService {
+
+	private static final int DEFAULT_LIMIT = 50;
+	private static final int MAX_LIMIT = 200;
+	private static final double DEFAULT_MIN_CONFIDENCE = 0.45d;
+	private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+
+	private final ProjectService projectService;
+	private final Map<String, Map<String, AlertChannelState>> channelsByProject = new HashMap<>();
+	private final Map<String, List<AuditLogState>> auditLogsByProject = new HashMap<>();
+
+	public AlertService(ProjectService projectService) {
+		this.projectService = projectService;
+	}
+
+	public synchronized ConfigureResult configureSlack(
+		String projectId,
+		String actorToken,
+		ConfigureSlackCommand command
+	) {
+		requireProjectForWrite(projectId);
+		if (command == null) {
+			throw new ValidationException("Request body must not be null");
+		}
+
+		String webhookUrl = validateWebhookUrl(command.webhookUrl());
+		String channel = requireNonBlank(command.channel(), "channel must not be blank");
+		double minConfidence = normalizeMinConfidence(command.minConfidence());
+
+		ConfigureResult result = upsertChannel(
+			projectId,
+			"slack",
+			new SlackConfig(webhookUrl, channel, minConfidence)
+		);
+
+		appendAuditLog(
+			projectId,
+			actorToken,
+			"alert.slack.configured",
+			result.channel().id(),
+			Map.of(
+				"type", "slack",
+				"channel", channel,
+				"min_confidence", minConfidence,
+				"created", result.created()
+			)
+		);
+
+		return result;
+	}
+
+	public synchronized ConfigureResult configureEmail(
+		String projectId,
+		String actorToken,
+		ConfigureEmailCommand command
+	) {
+		requireProjectForWrite(projectId);
+		if (command == null) {
+			throw new ValidationException("Request body must not be null");
+		}
+
+		String from = validateEmail(command.from(), "from must be a valid email");
+		List<String> recipients = validateRecipients(command.recipients());
+		SmtpConfig smtp = validateSmtp(command.smtp());
+		double minConfidence = normalizeMinConfidence(command.minConfidence());
+
+		ConfigureResult result = upsertChannel(
+			projectId,
+			"email",
+			new EmailConfig(from, recipients, smtp, minConfidence)
+		);
+
+		appendAuditLog(
+			projectId,
+			actorToken,
+			"alert.email.configured",
+			result.channel().id(),
+			Map.of(
+				"type", "email",
+				"from", from,
+				"recipients_count", recipients.size(),
+				"smtp_host", smtp.host(),
+				"smtp_port", smtp.port(),
+				"starttls", smtp.starttls(),
+				"min_confidence", minConfidence,
+				"created", result.created()
+			)
+		);
+
+		return result;
+	}
+
+	public synchronized AuditLogListResult listAuditLogs(String projectId, AuditLogQuery query) {
+		requireProjectForRead(projectId);
+		AuditLogQuery safeQuery = query == null
+			? new AuditLogQuery(null, null, null, null)
+			: query;
+
+		int limit = normalizeLimit(safeQuery.limit());
+		int offset = normalizeCursor(safeQuery.cursor());
+		String action = normalizeOptional(safeQuery.action());
+		String actor = normalizeOptional(safeQuery.actor());
+
+		List<AuditLogState> original = auditLogsByProject.getOrDefault(projectId, List.of());
+		List<AuditLogState> ordered = new ArrayList<>(original);
+		Collections.reverse(ordered);
+
+		List<AuditLogState> filtered = ordered.stream()
+			.filter(log -> action == null || log.action().equals(action))
+			.filter(log -> actor == null || log.actor().equals(actor))
+			.toList();
+
+		int start = Math.min(offset, filtered.size());
+		int end = Math.min(start + limit, filtered.size());
+		List<AuditLog> data = filtered.subList(start, end).stream()
+			.map(state -> new AuditLog(
+				state.id(),
+				state.actor(),
+				state.action(),
+				state.resourceType(),
+				state.resourceId(),
+				state.createdAt(),
+				state.metadata()
+			))
+			.toList();
+
+		String nextCursor = end < filtered.size() ? String.valueOf(end) : null;
+		return new AuditLogListResult(data, UUID.randomUUID().toString(), nextCursor);
+	}
+
+	private ConfigureResult upsertChannel(String projectId, String type, Object config) {
+		Map<String, AlertChannelState> channels = channelsByProject.computeIfAbsent(
+			projectId,
+			ignored -> new LinkedHashMap<>()
+		);
+		AlertChannelState existing = channels.get(type);
+
+		boolean created = existing == null;
+		String id = created ? UUID.randomUUID().toString() : existing.id();
+		Instant updatedAt = Instant.now();
+
+		AlertChannelState updated = new AlertChannelState(id, type, true, updatedAt, config);
+		channels.put(type, updated);
+		return new ConfigureResult(created, new AlertChannel(id, type, true, updatedAt));
+	}
+
+	private void appendAuditLog(
+		String projectId,
+		String actorToken,
+		String action,
+		String resourceId,
+		Map<String, Object> metadata
+	) {
+		List<AuditLogState> logs = auditLogsByProject.computeIfAbsent(projectId, ignored -> new ArrayList<>());
+		logs.add(new AuditLogState(
+			UUID.randomUUID().toString(),
+			maskActor(actorToken),
+			action,
+			"alert_channel",
+			resourceId,
+			Instant.now(),
+			Map.copyOf(metadata)
+		));
+	}
+
+	private void requireProjectForWrite(String projectId) {
+		if (projectId == null || projectId.isBlank() || !projectService.existsById(projectId)) {
+			throw new ValidationException("Project not found");
+		}
+	}
+
+	private void requireProjectForRead(String projectId) {
+		if (projectId == null || projectId.isBlank() || !projectService.existsById(projectId)) {
+			throw new NotFoundException("Project not found");
+		}
+	}
+
+	private String validateWebhookUrl(String webhookUrl) {
+		String normalized = requireNonBlank(webhookUrl, "webhook_url must be a valid URI");
+		try {
+			URI uri = new URI(normalized);
+			if (!uri.isAbsolute() || uri.getHost() == null) {
+				throw new ValidationException("webhook_url must be a valid URI");
+			}
+			String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+			if (!"http".equals(scheme) && !"https".equals(scheme)) {
+				throw new ValidationException("webhook_url must be a valid URI");
+			}
+		} catch (URISyntaxException exception) {
+			throw new ValidationException("webhook_url must be a valid URI");
+		}
+		return normalized;
+	}
+
+	private String validateEmail(String email, String message) {
+		String normalized = requireNonBlank(email, message);
+		if (!EMAIL_PATTERN.matcher(normalized).matches()) {
+			throw new ValidationException(message);
+		}
+		return normalized;
+	}
+
+	private List<String> validateRecipients(List<String> recipients) {
+		if (recipients == null || recipients.isEmpty()) {
+			throw new ValidationException("recipients must contain at least 1 email");
+		}
+
+		List<String> normalized = new ArrayList<>(recipients.size());
+		for (int index = 0; index < recipients.size(); index++) {
+			normalized.add(validateEmail(
+				recipients.get(index),
+				"recipients[%d] must be a valid email".formatted(index)
+			));
+		}
+		return List.copyOf(normalized);
+	}
+
+	private SmtpConfig validateSmtp(SmtpCommand smtp) {
+		if (smtp == null) {
+			throw new ValidationException("smtp must not be null");
+		}
+
+		String host = requireNonBlank(smtp.host(), "smtp.host must not be blank");
+		Integer port = smtp.port();
+		if (port == null || port < 1 || port > 65535) {
+			throw new ValidationException("smtp.port must be between 1 and 65535");
+		}
+
+		String username = requireNonBlank(smtp.username(), "smtp.username must not be blank");
+		String password = requireNonBlank(smtp.password(), "smtp.password must not be blank");
+		boolean starttls = smtp.starttls() == null || smtp.starttls();
+		return new SmtpConfig(host, port, username, password, starttls);
+	}
+
+	private double normalizeMinConfidence(Double minConfidence) {
+		double normalized = minConfidence == null ? DEFAULT_MIN_CONFIDENCE : minConfidence;
+		if (Double.isNaN(normalized) || normalized < 0 || normalized > 1) {
+			throw new ValidationException("min_confidence must be between 0 and 1");
+		}
+		return normalized;
+	}
+
+	private int normalizeLimit(Integer limit) {
+		int normalized = limit == null ? DEFAULT_LIMIT : limit;
+		if (normalized < 1 || normalized > MAX_LIMIT) {
+			throw new ValidationException("limit must be between 1 and 200");
+		}
+		return normalized;
+	}
+
+	private int normalizeCursor(String cursor) {
+		String normalized = normalizeOptional(cursor);
+		if (normalized == null) {
+			return 0;
+		}
+		try {
+			int parsed = Integer.parseInt(normalized);
+			if (parsed < 0) {
+				throw new ValidationException("cursor must be a non-negative integer");
+			}
+			return parsed;
+		} catch (NumberFormatException exception) {
+			throw new ValidationException("cursor must be a non-negative integer");
+		}
+	}
+
+	private String maskActor(String actorToken) {
+		String normalized = normalizeOptional(actorToken);
+		if (normalized == null) {
+			return "token:anonymous";
+		}
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] bytes = digest.digest(normalized.getBytes());
+			String hex = HexFormat.of().formatHex(bytes);
+			return "token:" + hex.substring(0, 12);
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256 is not available", exception);
+		}
+	}
+
+	private String requireNonBlank(String value, String message) {
+		String normalized = normalizeOptional(value);
+		if (normalized == null) {
+			throw new ValidationException(message);
+		}
+		return normalized;
+	}
+
+	private String normalizeOptional(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	public record ConfigureSlackCommand(
+		String webhookUrl,
+		String channel,
+		Double minConfidence
+	) {
+	}
+
+	public record ConfigureEmailCommand(
+		String from,
+		List<String> recipients,
+		SmtpCommand smtp,
+		Double minConfidence
+	) {
+	}
+
+	public record SmtpCommand(
+		String host,
+		Integer port,
+		String username,
+		String password,
+		Boolean starttls
+	) {
+	}
+
+	public record ConfigureResult(
+		boolean created,
+		AlertChannel channel
+	) {
+	}
+
+	public record AlertChannel(
+		String id,
+		String type,
+		boolean enabled,
+		Instant updatedAt
+	) {
+	}
+
+	public record AuditLogQuery(
+		String action,
+		String actor,
+		String cursor,
+		Integer limit
+	) {
+	}
+
+	public record AuditLogListResult(
+		List<AuditLog> data,
+		String requestId,
+		String nextCursor
+	) {
+	}
+
+	public record AuditLog(
+		String id,
+		String actor,
+		String action,
+		String resourceType,
+		String resourceId,
+		Instant createdAt,
+		Map<String, Object> metadata
+	) {
+	}
+
+	private record AlertChannelState(
+		String id,
+		String type,
+		boolean enabled,
+		Instant updatedAt,
+		Object config
+	) {
+	}
+
+	private record SlackConfig(
+		String webhookUrl,
+		String channel,
+		double minConfidence
+	) {
+	}
+
+	private record EmailConfig(
+		String from,
+		List<String> recipients,
+		SmtpConfig smtp,
+		double minConfidence
+	) {
+	}
+
+	private record SmtpConfig(
+		String host,
+		int port,
+		String username,
+		String password,
+		boolean starttls
+	) {
+	}
+
+	private record AuditLogState(
+		String id,
+		String actor,
+		String action,
+		String resourceType,
+		String resourceId,
+		Instant createdAt,
+		Map<String, Object> metadata
+	) {
+	}
+}

--- a/src/main/java/com/logcopilot/alert/AlertService.java
+++ b/src/main/java/com/logcopilot/alert/AlertService.java
@@ -5,6 +5,7 @@ import com.logcopilot.common.error.ValidationException;
 import com.logcopilot.project.ProjectService;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.MessageDigest;
@@ -101,7 +102,7 @@ public class AlertService {
 			result.channel().id(),
 			Map.of(
 				"type", "email",
-				"from", from,
+				"from", maskEmailForAudit(from),
 				"recipients_count", recipients.size(),
 				"smtp_host", smtp.host(),
 				"smtp_port", smtp.port(),
@@ -295,12 +296,25 @@ public class AlertService {
 		}
 		try {
 			MessageDigest digest = MessageDigest.getInstance("SHA-256");
-			byte[] bytes = digest.digest(normalized.getBytes());
+			byte[] bytes = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
 			String hex = HexFormat.of().formatHex(bytes);
 			return "token:" + hex.substring(0, 12);
 		} catch (NoSuchAlgorithmException exception) {
 			throw new IllegalStateException("SHA-256 is not available", exception);
 		}
+	}
+
+	private String maskEmailForAudit(String email) {
+		String normalized = normalizeOptional(email);
+		if (normalized == null) {
+			return "domain:unknown";
+		}
+
+		int atIndex = normalized.lastIndexOf('@');
+		if (atIndex < 0 || atIndex == normalized.length() - 1) {
+			return "domain:unknown";
+		}
+		return "domain:" + normalized.substring(atIndex + 1).toLowerCase(Locale.ROOT);
 	}
 
 	private String requireNonBlank(String value, String message) {

--- a/src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java
@@ -123,6 +123,48 @@ class AlertEndpointsContractTest {
 	}
 
 	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/email 는 기존 채널 설정 시 200으로 갱신한다")
+	void configureEmailReturns200OnUpdate() throws Exception {
+		String projectId = createProjectId("alert-email-update");
+
+		MvcResult created = mockMvc.perform(post("/v1/projects/{project_id}/alerts/email", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emailRequestBody(
+					"alerts@example.com",
+					"\"oncall@example.com\"",
+					"smtp.example.com",
+					587,
+					"smtp-user",
+					"smtp-secret",
+					true,
+					0.6
+				)))
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		String channelId = jsonValue(created, "/data/id");
+		assertThat(channelId).isNotBlank();
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/email", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emailRequestBody(
+					"alerts@example.com",
+					"\"sre@example.com\",\"lead@example.com\"",
+					"smtp.example.com",
+					587,
+					"smtp-user",
+					"smtp-secret",
+					true,
+					0.7
+				)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(channelId))
+			.andExpect(jsonPath("$.data.type").value("email"));
+	}
+
+	@Test
 	@DisplayName("POST /v1/projects/{project_id}/alerts/email 는 recipients가 비면 422를 반환한다")
 	void configureEmailReturns422WhenRecipientsEmpty() throws Exception {
 		String projectId = createProjectId("alert-email-invalid-recipients");

--- a/src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java
@@ -227,6 +227,10 @@ class AlertEndpointsContractTest {
 
 		String actor = jsonValue(firstPage, "/data/0/actor");
 		String nextCursor = jsonValue(firstPage, "/meta/next_cursor");
+		assertThat(actor)
+			.startsWith("token:")
+			.doesNotContain("actor-token-a")
+			.doesNotContain("actor-token-b");
 
 		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId)
 				.header("Authorization", "Bearer reader-token")

--- a/src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/alert/AlertEndpointsContractTest.java
@@ -1,0 +1,320 @@
+package com.logcopilot.alert;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class AlertEndpointsContractTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/slack 는 신규 설정 시 201을 반환한다")
+	void configureSlackReturns201OnCreate() throws Exception {
+		String projectId = createProjectId("alert-slack-create");
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/slack", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(slackRequestBody("https://hooks.slack.com/services/T000/B000/XXX", "#ops", 0.45)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.id").isString())
+			.andExpect(jsonPath("$.data.type").value("slack"))
+			.andExpect(jsonPath("$.data.enabled").value(true))
+			.andExpect(jsonPath("$.data.updated_at").isString());
+	}
+
+	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/slack 는 기존 채널 설정 시 200으로 갱신한다")
+	void configureSlackReturns200OnUpdate() throws Exception {
+		String projectId = createProjectId("alert-slack-update");
+
+		MvcResult created = mockMvc.perform(post("/v1/projects/{project_id}/alerts/slack", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(slackRequestBody("https://hooks.slack.com/services/T000/B000/AAA", "#ops", 0.40)))
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		String channelId = jsonValue(created, "/data/id");
+		assertThat(channelId).isNotBlank();
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/slack", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(slackRequestBody("https://hooks.slack.com/services/T000/B000/BBB", "#platform", 0.80)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(channelId))
+			.andExpect(jsonPath("$.data.type").value("slack"));
+	}
+
+	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/slack 는 인증 누락 시 401을 반환한다")
+	void configureSlackRejectsMissingBearerToken() throws Exception {
+		String projectId = createProjectId("alert-slack-auth");
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/slack", projectId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(slackRequestBody("https://hooks.slack.com/services/T000/B000/XXX", "#ops", 0.45)))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.error.code").value("unauthorized"))
+			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
+	}
+
+	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/slack 는 webhook_url이 잘못되면 422를 반환한다")
+	void configureSlackReturns422WhenWebhookInvalid() throws Exception {
+		String projectId = createProjectId("alert-slack-invalid-webhook");
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/slack", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(slackRequestBody("invalid-uri", "#ops", 0.45)))
+			.andExpect(status().isUnprocessableEntity())
+			.andExpect(jsonPath("$.error.code").value("validation_error"))
+			.andExpect(jsonPath("$.error.message").value("webhook_url must be a valid URI"));
+	}
+
+	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/email 는 신규 설정 시 201을 반환한다")
+	void configureEmailReturns201OnCreate() throws Exception {
+		String projectId = createProjectId("alert-email-create");
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/email", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emailRequestBody(
+					"alerts@example.com",
+					"\"oncall@example.com\",\"lead@example.com\"",
+					"smtp.example.com",
+					587,
+					"smtp-user",
+					"smtp-secret",
+					true,
+					0.6
+				)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.id").isString())
+			.andExpect(jsonPath("$.data.type").value("email"))
+			.andExpect(jsonPath("$.data.enabled").value(true));
+	}
+
+	@Test
+	@DisplayName("POST /v1/projects/{project_id}/alerts/email 는 recipients가 비면 422를 반환한다")
+	void configureEmailReturns422WhenRecipientsEmpty() throws Exception {
+		String projectId = createProjectId("alert-email-invalid-recipients");
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/email", projectId)
+				.header("Authorization", "Bearer alert-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emailRequestBody(
+					"alerts@example.com",
+					null,
+					"smtp.example.com",
+					587,
+					"smtp-user",
+					"smtp-secret",
+					true,
+					0.6
+				)))
+			.andExpect(status().isUnprocessableEntity())
+			.andExpect(jsonPath("$.error.code").value("validation_error"))
+			.andExpect(jsonPath("$.error.message").value("recipients must contain at least 1 email"));
+	}
+
+	@Test
+	@DisplayName("GET /v1/projects/{project_id}/audit-logs 는 필터와 커서를 적용해 200을 반환한다")
+	void listAuditLogsReturnsFilteredLogsWithPagination() throws Exception {
+		String projectId = createProjectId("audit-log-list");
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/slack", projectId)
+				.header("Authorization", "Bearer actor-token-a")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(slackRequestBody("https://hooks.slack.com/services/T000/B000/AAA", "#ops", 0.5)))
+			.andExpect(status().isCreated());
+
+		mockMvc.perform(post("/v1/projects/{project_id}/alerts/email", projectId)
+				.header("Authorization", "Bearer actor-token-b")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emailRequestBody(
+					"alerts@example.com",
+					"\"oncall@example.com\"",
+					"smtp.example.com",
+					587,
+					"smtp-user",
+					"smtp-secret",
+					true,
+					0.7
+				)))
+			.andExpect(status().isCreated());
+
+		MvcResult firstPage = mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId)
+				.header("Authorization", "Bearer reader-token")
+				.queryParam("limit", "1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].id").isString())
+			.andExpect(jsonPath("$.data[0].action").isString())
+			.andExpect(jsonPath("$.data[0].resource_type").value("alert_channel"))
+			.andExpect(jsonPath("$.meta.request_id").isString())
+			.andExpect(jsonPath("$.meta.next_cursor").isString())
+			.andReturn();
+
+		String actor = jsonValue(firstPage, "/data/0/actor");
+		String nextCursor = jsonValue(firstPage, "/meta/next_cursor");
+
+		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId)
+				.header("Authorization", "Bearer reader-token")
+				.queryParam("cursor", nextCursor)
+				.queryParam("limit", "1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1));
+
+		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId)
+				.header("Authorization", "Bearer reader-token")
+				.queryParam("action", "alert.email.configured"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].action").value("alert.email.configured"));
+
+		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId)
+				.header("Authorization", "Bearer reader-token")
+				.queryParam("actor", actor))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].actor").value(actor));
+	}
+
+	@Test
+	@DisplayName("GET /v1/projects/{project_id}/audit-logs 는 인증 누락 시 401을 반환한다")
+	void listAuditLogsRejectsMissingBearerToken() throws Exception {
+		String projectId = createProjectId("audit-log-auth");
+
+		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.error.code").value("unauthorized"))
+			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
+	}
+
+	@Test
+	@DisplayName("GET /v1/projects/{project_id}/audit-logs 는 프로젝트가 없으면 404를 반환한다")
+	void listAuditLogsReturns404WhenProjectMissing() throws Exception {
+		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", "missing-project")
+				.header("Authorization", "Bearer reader-token"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error.code").value("not_found"))
+			.andExpect(jsonPath("$.error.message").value("Project not found"));
+	}
+
+	@Test
+	@DisplayName("GET /v1/projects/{project_id}/audit-logs 는 limit이 범위를 벗어나면 422를 반환한다")
+	void listAuditLogsReturns422WhenLimitOutOfRange() throws Exception {
+		String projectId = createProjectId("audit-log-limit");
+
+		mockMvc.perform(get("/v1/projects/{project_id}/audit-logs", projectId)
+				.header("Authorization", "Bearer reader-token")
+				.queryParam("limit", "201"))
+			.andExpect(status().isUnprocessableEntity())
+			.andExpect(jsonPath("$.error.code").value("validation_error"))
+			.andExpect(jsonPath("$.error.message").value("limit must be between 1 and 200"));
+	}
+
+	private String createProjectId(String namePrefix) throws Exception {
+		String projectName = namePrefix + "-" + UUID.randomUUID();
+
+		MvcResult result = mockMvc.perform(post("/v1/projects")
+				.header("Authorization", "Bearer project-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(projectRequestBody(projectName, "prod")))
+			.andExpect(status().isCreated())
+			.andReturn();
+
+		String projectId = jsonValue(result, "/data/id");
+		assertThat(projectId).isNotBlank();
+		return projectId;
+	}
+
+	private String projectRequestBody(String name, String environment) {
+		return """
+			{
+			  "name": "%s",
+			  "environment": "%s"
+			}
+			""".formatted(name, environment);
+	}
+
+	private String slackRequestBody(String webhookUrl, String channel, Double minConfidence) {
+		return """
+			{
+			  "webhook_url": "%s",
+			  "channel": "%s",
+			  "min_confidence": %s
+			}
+			""".formatted(webhookUrl, channel, minConfidence == null ? "null" : minConfidence);
+	}
+
+	private String emailRequestBody(
+		String from,
+		String recipientsJson,
+		String host,
+		int port,
+		String username,
+		String password,
+		boolean starttls,
+		Double minConfidence
+	) {
+		String recipients = recipientsJson == null ? "[]" : "[" + recipientsJson + "]";
+		return """
+			{
+			  "from": "%s",
+			  "recipients": %s,
+			  "smtp": {
+			    "host": "%s",
+			    "port": %d,
+			    "username": "%s",
+			    "password": "%s",
+			    "starttls": %s
+			  },
+			  "min_confidence": %s
+			}
+			""".formatted(
+			from,
+			recipients,
+			host,
+			port,
+			username,
+			password,
+			starttls,
+			minConfidence == null ? "null" : minConfidence
+		);
+	}
+
+	private String jsonValue(MvcResult result, String pointer) throws Exception {
+		JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+		JsonNode node = root.at(pointer);
+		return node.isMissingNode() || node.isNull() ? null : node.asText();
+	}
+}

--- a/src/test/java/com/logcopilot/alert/AlertServiceTest.java
+++ b/src/test/java/com/logcopilot/alert/AlertServiceTest.java
@@ -150,6 +150,7 @@ class AlertServiceTest {
 		assertThat(second.data()).hasSize(1);
 		assertThat(byAction.data()).hasSize(1);
 		assertThat(byAction.data().get(0).action()).isEqualTo("alert.email.configured");
+		assertThat(byAction.data().get(0).metadata().get("from")).isEqualTo("domain:example.com");
 		assertThat(byActor.data()).allMatch(log -> log.actor().equals(actor));
 	}
 

--- a/src/test/java/com/logcopilot/alert/AlertServiceTest.java
+++ b/src/test/java/com/logcopilot/alert/AlertServiceTest.java
@@ -1,0 +1,179 @@
+package com.logcopilot.alert;
+
+import com.logcopilot.common.error.NotFoundException;
+import com.logcopilot.common.error.ValidationException;
+import com.logcopilot.project.ProjectDto;
+import com.logcopilot.project.ProjectService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AlertServiceTest {
+
+	private final ProjectService projectService = new ProjectService();
+	private final AlertService alertService = new AlertService(projectService);
+
+	@Test
+	@DisplayName("AlertService는 Slack 채널을 생성 후 동일 타입 요청을 갱신하고 감사 로그를 남긴다")
+	void configureSlackCreatesThenUpdatesAndAppendsAuditLog() {
+		ProjectDto project = projectService.create("alert-service-slack", "prod");
+
+		AlertService.ConfigureResult created = alertService.configureSlack(
+			project.id(),
+			"actor-a",
+			new AlertService.ConfigureSlackCommand(
+				"https://hooks.slack.com/services/T000/B000/AAA",
+				"#ops",
+				0.45
+			)
+		);
+
+		AlertService.ConfigureResult updated = alertService.configureSlack(
+			project.id(),
+			"actor-a",
+			new AlertService.ConfigureSlackCommand(
+				"https://hooks.slack.com/services/T000/B000/BBB",
+				"#platform",
+				0.70
+			)
+		);
+
+		AlertService.AuditLogListResult logs = alertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery(null, null, null, 50)
+		);
+
+		assertThat(created.created()).isTrue();
+		assertThat(updated.created()).isFalse();
+		assertThat(updated.channel().id()).isEqualTo(created.channel().id());
+		assertThat(logs.data()).hasSize(2);
+		assertThat(logs.data().get(0).action()).isEqualTo("alert.slack.configured");
+	}
+
+	@Test
+	@DisplayName("AlertService는 Email 요청의 주소/수신자 유효성을 검증한다")
+	void configureEmailValidatesAddresses() {
+		ProjectDto project = projectService.create("alert-service-email", "prod");
+
+		assertThatThrownBy(() -> alertService.configureEmail(
+			project.id(),
+			"actor-a",
+			new AlertService.ConfigureEmailCommand(
+				"invalid-email",
+				List.of("oncall@example.com"),
+				new AlertService.SmtpCommand("smtp.example.com", 587, "user", "secret", true),
+				0.45
+			)
+		))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("from must be a valid email");
+
+		assertThatThrownBy(() -> alertService.configureEmail(
+			project.id(),
+			"actor-a",
+			new AlertService.ConfigureEmailCommand(
+				"alerts@example.com",
+				List.of(),
+				new AlertService.SmtpCommand("smtp.example.com", 587, "user", "secret", true),
+				0.45
+			)
+		))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("recipients must contain at least 1 email");
+	}
+
+	@Test
+	@DisplayName("AlertService는 존재하지 않는 프로젝트 알림 설정 요청 시 ValidationException을 던진다")
+	void configureThrowsValidationWhenProjectMissing() {
+		assertThatThrownBy(() -> alertService.configureSlack(
+			"missing-project",
+			"actor-a",
+			new AlertService.ConfigureSlackCommand(
+				"https://hooks.slack.com/services/T000/B000/AAA",
+				"#ops",
+				0.45
+			)
+		))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("Project not found");
+	}
+
+	@Test
+	@DisplayName("AlertService는 audit 로그 조회에서 action/actor/cursor/limit을 적용한다")
+	void listAuditLogsAppliesFiltersAndPagination() {
+		ProjectDto project = projectService.create("alert-service-audit", "prod");
+
+		alertService.configureSlack(
+			project.id(),
+			"actor-a",
+			new AlertService.ConfigureSlackCommand(
+				"https://hooks.slack.com/services/T000/B000/AAA",
+				"#ops",
+				0.45
+			)
+		);
+		alertService.configureEmail(
+			project.id(),
+			"actor-b",
+			new AlertService.ConfigureEmailCommand(
+				"alerts@example.com",
+				List.of("oncall@example.com"),
+				new AlertService.SmtpCommand("smtp.example.com", 587, "user", "secret", true),
+				0.7
+			)
+		);
+
+		AlertService.AuditLogListResult first = alertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery(null, null, null, 1)
+		);
+		AlertService.AuditLogListResult second = alertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery(null, null, first.nextCursor(), 1)
+		);
+		AlertService.AuditLogListResult byAction = alertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery("alert.email.configured", null, null, 50)
+		);
+		String actor = first.data().get(0).actor();
+		AlertService.AuditLogListResult byActor = alertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery(null, actor, null, 50)
+		);
+
+		assertThat(first.data()).hasSize(1);
+		assertThat(first.nextCursor()).isEqualTo("1");
+		assertThat(second.data()).hasSize(1);
+		assertThat(byAction.data()).hasSize(1);
+		assertThat(byAction.data().get(0).action()).isEqualTo("alert.email.configured");
+		assertThat(byActor.data()).allMatch(log -> log.actor().equals(actor));
+	}
+
+	@Test
+	@DisplayName("AlertService는 audit 조회 limit 범위를 벗어나면 ValidationException을 던진다")
+	void listAuditLogsThrowsWhenLimitOutOfRange() {
+		ProjectDto project = projectService.create("alert-service-limit", "prod");
+
+		assertThatThrownBy(() -> alertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery(null, null, null, 201)
+		))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("limit must be between 1 and 200");
+	}
+
+	@Test
+	@DisplayName("AlertService는 존재하지 않는 프로젝트 audit 조회 시 NotFoundException을 던진다")
+	void listAuditLogsThrowsNotFoundWhenProjectMissing() {
+		assertThatThrownBy(() -> alertService.listAuditLogs(
+			"missing-project",
+			new AlertService.AuditLogQuery(null, null, null, 50)
+		))
+			.isInstanceOf(NotFoundException.class)
+			.hasMessage("Project not found");
+	}
+}


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - Alert 채널 설정 API(`slack`, `email`)와 Audit 로그 조회 API를 구현했습니다.
  - Alert/Audit 단위/계약 테스트를 추가하고 T-09 세션 노트를 작성했습니다.
- 왜 필요한가:
  - `docs/specs/2026-03-03-mvp-v1-work-unit-bootstrap.md`의 T-09 완료 조건(채널 설정 + 감사 로그 조회)을 충족하기 위해 필요합니다.

## 연결 이슈
- Closes #26

## 범위 점검
- 포함:
  - `POST /v1/projects/{project_id}/alerts/slack`
  - `POST /v1/projects/{project_id}/alerts/email`
  - `GET /v1/projects/{project_id}/audit-logs`
  - Alert/Audit 서비스 로직 및 테스트
- 제외:
  - 실제 Slack/SMTP 외부 전송 연동
  - Alert/Audit 영속 저장소 도입

## 주요 변경 사항
- `AlertController` 추가: 인증/요청 매핑/응답 스키마(snake_case) 구현.
- `AlertService` 추가: 채널 upsert(201/200), 입력 검증(422), 감사 로그 append/list(필터+커서+limit) 구현.
- `AlertEndpointsContractTest`/`AlertServiceTest` 추가로 계약/단위 보장.
- `docs/sessions/2026-03-03-T-09.md` 추가.

## TDD 근거
- RED:
  - `./gradlew test --tests "*Alert*Test"` 실행 시 `AlertService` 미구현으로 `compileTestJava` 실패(26 errors).
- GREEN:
  - `./gradlew test --tests "*Alert*Test"` PASS
  - `./gradlew test --tests "*AlertEndpointsContractTest"` PASS
- REFACTOR:
  - Alert upsert 공통 메서드(`upsertChannel`) 도입.
  - Audit actor 토큰 해시(`token:<sha256-prefix>`) 저장으로 원문 노출 방지.

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: N/A (의존성/설정/멀티모듈 영향 없음)

## Rule-Base 근거
- AC1 -> `./gradlew test --tests "*AlertEndpointsContractTest"` -> PASS
- AC2 -> `./gradlew test --tests "*Alert*Test"` -> PASS
- AC3 -> `./gradlew test && ./gradlew check` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - pending
- codex:
  - pending

## 리스크 / 롤백
- 확인된 리스크:
  - Alert/Audit 저장이 in-memory라 재시작 시 유실됩니다.
  - actor는 해시 토큰 기반이라 실제 사용자 식별 체계와 분리됩니다.
- 롤백 계획:
  - 본 PR revert 시 Alert/Audit 추가 코드만 제거되어 기존 기능으로 복귀 가능합니다.

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-10에서 Alert/Audit 영속화 전략과 신뢰성 하드닝을 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Slack 및 이메일 알림 채널 설정 기능 추가 — 프로젝트별 알림 구성 지원
* REST API 엔드포인트를 통한 알림 채널 생성 및 업데이트 — Webhook, SMTP 설정 및 신뢰도 임계값 커스터마이징 가능
* 감사 로그 조회 및 필터링 기능 — 액션 및 담당자별 검색, 페이지네이션 지원으로 리소스 변경 이력 추적 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->