### PR TITLE
[WU-11] T-10 신뢰성 하드닝 + 필수 게이트 종료

### DIFF
--- a/docs/sessions/2026-03-03-T-10.md
+++ b/docs/sessions/2026-03-03-T-10.md
@@ -1,0 +1,93 @@
+# Session Task Note - T-10
+
+## Metadata
+- Date: 2026-03-03
+- Issue: #28
+- Branch: `feature/28-t10-reliability-hardening`
+- Task ID: T-10
+- Related spec: `docs/specs/2026-03-03-mvp-v1-work-unit-bootstrap.md`
+
+## 1. Intent Check
+- Do now:
+  - Alert/Audit in-memory 경로의 무한 성장 리스크를 줄이기 위해 프로젝트별 audit log retention 상한을 도입한다.
+  - Redaction regex 입력의 성능 리스크를 줄이기 위해 패턴 길이 상한 검증을 추가한다.
+  - 필수 게이트(`check`, `test`)와 조건부 게이트(`build`)를 실행해 종료 조건을 충족한다.
+- Do not do now:
+  - 외부 DB 영속화 전환 및 마이그레이션 도입.
+  - 실제 Slack/SMTP 전송 재시도/큐 처리.
+  - LLM/Loki 비밀값 암호화 저장소 구현.
+- Done means:
+  - Alert audit log가 프로젝트별 retention 상한 내에서만 유지된다.
+  - 과도하게 긴 redaction regex 패턴 입력이 API/서비스 레벨에서 차단된다.
+  - `./gradlew check`, `./gradlew test`, `./gradlew build`가 모두 PASS다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction` -> `openapi` -> `architecture-guardrails` -> workflow 문서 순으로 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - In scope의 "Export/redaction policy and audit logs" 및 운영 하드닝 범위에 해당.
+- AC-to-rule mapping to execute:
+  - AC1(audit retention 상한) -> Unit -> `./gradlew test --tests "*AlertServiceTest"` -> PASS
+  - AC2(regex 길이 가드) -> Unit/Integration -> `./gradlew test --tests "*PolicyServiceTest" --tests "*PolicyEndpointsContractTest"` -> PASS
+  - AC3(필수 게이트 종료) -> Build/Test -> `./gradlew check && ./gradlew test && ./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. Alert/Policy 신뢰성 하드닝 요구를 테스트로 먼저 고정한다.
+2. 서비스 로직을 최소 수정해 RED를 GREEN으로 전환한다.
+3. 전체 게이트와 딴지 리뷰를 수행하고 결과를 기록한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/alert/AlertServiceTest.java`
+  - `src/test/java/com/logcopilot/policy/PolicyServiceTest.java`
+  - `src/test/java/com/logcopilot/policy/PolicyEndpointsContractTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*AlertServiceTest" --tests "*PolicyServiceTest" --tests "*PolicyEndpointsContractTest"` 실행 시 `AlertService`에 retention 주입 생성자가 없어 `compileTestJava` 실패.
+- GREEN pass output summary:
+  - `./gradlew test --tests "*AlertServiceTest" --tests "*PolicyServiceTest" --tests "*PolicyEndpointsContractTest"` PASS
+  - `./gradlew check` PASS
+  - `./gradlew test` PASS
+  - `./gradlew build` PASS
+- REFACTOR summary:
+  - AlertService 기본/테스트용 생성자 경계를 분리하고 기본 retention 상수를 도입했다.
+  - PolicyService regex guard 상수를 분리해 검증 의도를 명확히 했다.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/alert/AlertService.java`
+  - `src/main/java/com/logcopilot/policy/PolicyService.java`
+  - `src/test/java/com/logcopilot/alert/AlertServiceTest.java`
+  - `src/test/java/com/logcopilot/policy/PolicyServiceTest.java`
+  - `src/test/java/com/logcopilot/policy/PolicyEndpointsContractTest.java`
+- Why this approach:
+  - OpenAPI 계약을 깨지 않으면서 운영 리스크(메모리 증가, 비용 큰 regex)를 줄이는 최소 변경이다.
+  - 영속 저장소 전환 없이도 즉시 적용 가능한 신뢰성 개선(상한/검증)이라 회귀 위험이 낮다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*AlertServiceTest" --tests "*PolicyServiceTest" --tests "*PolicyEndpointsContractTest"`
+  - `./gradlew check`
+  - `./gradlew test`
+  - `./gradlew build`
+- Results:
+  - RED 1회 실패 확인 후 GREEN/필수 게이트/조건부 게이트 모두 PASS.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Self-review (OpenAPI 계약, guardrail, 메모리/성능 리스크 관점).
+- Findings:
+  - retention 상한은 메모리 폭증 리스크를 줄이지만 프로세스 재시작 내구성은 해결하지 못한다.
+  - regex 길이 제한은 1차 방어이며 모든 ReDoS 패턴을 완전 차단하지는 않는다.
+- Resolution:
+  - T-10 범위에서는 운영 급한 리스크(무한 증가/과도 입력)를 우선 차단했다.
+  - 영속화 및 고급 regex 안전성(타임아웃/엔진 격리)은 후속 태스크로 추적한다.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - Alert/Policy/LLM 설정은 여전히 프로세스 재시작 시 유실되는 in-memory 구조다.
+  - 비밀값 저장 암호화 및 감사 로그의 장기 보존 전략이 필요하다.
+- Next task ID:
+  - T-11.
+- Suggested first check for next session:
+  - PR 피드백 루프 시작 전에 현재 하드닝 범위와 잔여 리스크(영속화/비밀값 암호화)를 PR 본문에 명시할 것.

--- a/src/main/java/com/logcopilot/alert/AlertService.java
+++ b/src/main/java/com/logcopilot/alert/AlertService.java
@@ -3,6 +3,7 @@ package com.logcopilot.alert;
 import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.common.error.ValidationException;
 import com.logcopilot.project.ProjectService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -28,14 +29,25 @@ public class AlertService {
 	private static final int DEFAULT_LIMIT = 50;
 	private static final int MAX_LIMIT = 200;
 	private static final double DEFAULT_MIN_CONFIDENCE = 0.45d;
+	private static final int DEFAULT_MAX_AUDIT_LOGS_PER_PROJECT = 5_000;
 	private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
 
 	private final ProjectService projectService;
+	private final int maxAuditLogsPerProject;
 	private final Map<String, Map<String, AlertChannelState>> channelsByProject = new HashMap<>();
 	private final Map<String, List<AuditLogState>> auditLogsByProject = new HashMap<>();
 
+	@Autowired
 	public AlertService(ProjectService projectService) {
+		this(projectService, DEFAULT_MAX_AUDIT_LOGS_PER_PROJECT);
+	}
+
+	AlertService(ProjectService projectService, int maxAuditLogsPerProject) {
+		if (maxAuditLogsPerProject < 1) {
+			throw new IllegalArgumentException("maxAuditLogsPerProject must be >= 1");
+		}
 		this.projectService = projectService;
+		this.maxAuditLogsPerProject = maxAuditLogsPerProject;
 	}
 
 	public synchronized ConfigureResult configureSlack(
@@ -186,6 +198,9 @@ public class AlertService {
 			Instant.now(),
 			Map.copyOf(metadata)
 		));
+		while (logs.size() > maxAuditLogsPerProject) {
+			logs.remove(0);
+		}
 	}
 
 	private void requireProjectForWrite(String projectId) {

--- a/src/main/java/com/logcopilot/policy/PolicyService.java
+++ b/src/main/java/com/logcopilot/policy/PolicyService.java
@@ -17,6 +17,7 @@ import java.util.regex.PatternSyntaxException;
 public class PolicyService {
 
 	private static final int MAX_REDACTION_RULES = 200;
+	private static final int MAX_REGEX_PATTERN_LENGTH = 512;
 	private static final Pattern NESTED_QUANTIFIER_PATTERN =
 		Pattern.compile(
 			"\\((?:[^()\\\\]|\\\\.)*(?:[+*?]|\\{\\d+(?:,\\d*)?\\})(?:[^()\\\\]|\\\\.)*\\)(?:[+*?]|\\{\\d+(?:,\\d*)?\\})"
@@ -130,6 +131,12 @@ public class PolicyService {
 	}
 
 	private void validateRegex(int index, String pattern) {
+		if (pattern.length() > MAX_REGEX_PATTERN_LENGTH) {
+			throw new BadRequestException(
+				"rules[%d].pattern must be at most %d characters".formatted(index, MAX_REGEX_PATTERN_LENGTH)
+			);
+		}
+
 		if (NESTED_QUANTIFIER_PATTERN.matcher(pattern).find()) {
 			throw new BadRequestException(
 				"rules[%d].pattern contains disallowed nested quantifier".formatted(index)

--- a/src/test/java/com/logcopilot/alert/AlertServiceTest.java
+++ b/src/test/java/com/logcopilot/alert/AlertServiceTest.java
@@ -168,6 +168,53 @@ class AlertServiceTest {
 	}
 
 	@Test
+	@DisplayName("AlertService는 프로젝트별 audit 로그를 retention 상한까지만 유지한다")
+	void listAuditLogsKeepsOnlyRecentLogsWithinRetentionLimit() {
+		ProjectDto project = projectService.create("alert-service-retention", "prod");
+		AlertService limitedAlertService = new AlertService(projectService, 2);
+
+		limitedAlertService.configureSlack(
+			project.id(),
+			"actor-old",
+			new AlertService.ConfigureSlackCommand(
+				"https://hooks.slack.com/services/T000/B000/OLD",
+				"#old",
+				0.45
+			)
+		);
+		limitedAlertService.configureEmail(
+			project.id(),
+			"actor-mid",
+			new AlertService.ConfigureEmailCommand(
+				"alerts@example.com",
+				List.of("oncall@example.com"),
+				new AlertService.SmtpCommand("smtp.example.com", 587, "user", "secret", true),
+				0.5
+			)
+		);
+		limitedAlertService.configureSlack(
+			project.id(),
+			"actor-new",
+			new AlertService.ConfigureSlackCommand(
+				"https://hooks.slack.com/services/T000/B000/NEW",
+				"#new",
+				0.9
+			)
+		);
+
+		AlertService.AuditLogListResult logs = limitedAlertService.listAuditLogs(
+			project.id(),
+			new AlertService.AuditLogQuery(null, null, null, 50)
+		);
+
+		assertThat(logs.data()).hasSize(2);
+		assertThat(logs.data())
+			.noneMatch(log -> "#old".equals(log.metadata().get("channel")));
+		assertThat(logs.data())
+			.anyMatch(log -> "#new".equals(log.metadata().get("channel")));
+	}
+
+	@Test
 	@DisplayName("AlertService는 존재하지 않는 프로젝트 audit 조회 시 NotFoundException을 던진다")
 	void listAuditLogsThrowsNotFoundWhenProjectMissing() {
 		assertThatThrownBy(() -> alertService.listAuditLogs(

--- a/src/test/java/com/logcopilot/policy/PolicyEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/policy/PolicyEndpointsContractTest.java
@@ -155,6 +155,28 @@ class PolicyEndpointsContractTest {
 			.andExpect(jsonPath("$.error.message").value("rules[0].pattern must be a valid regex"));
 	}
 
+	@Test
+	@DisplayName("PUT /v1/projects/{project_id}/policies/redaction 는 과도하게 긴 정규식이면 400을 반환한다")
+	void updateRedactionPolicyReturns400WhenPatternTooLong() throws Exception {
+		String projectId = createProjectId("policy-redaction-long-pattern");
+		String longPattern = "a".repeat(513);
+
+		mockMvc.perform(put("/v1/projects/{project_id}/policies/redaction", projectId)
+				.header("Authorization", "Bearer policy-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(redactionRequestBody(
+					true,
+					"""
+					[
+					  {"name":"long-pattern","pattern":"%s","replace_with":"[MASKED]"}
+					]
+					""".formatted(longPattern)
+				)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("bad_request"))
+			.andExpect(jsonPath("$.error.message").value("rules[0].pattern must be at most 512 characters"));
+	}
+
 	private String createProjectId(String namePrefix) throws Exception {
 		String projectName = namePrefix + "-" + UUID.randomUUID();
 

--- a/src/test/java/com/logcopilot/policy/PolicyServiceTest.java
+++ b/src/test/java/com/logcopilot/policy/PolicyServiceTest.java
@@ -150,4 +150,21 @@ class PolicyServiceTest {
 			.isInstanceOf(BadRequestException.class)
 			.hasMessage("rules[0].pattern contains disallowed nested quantifier");
 	}
+
+	@Test
+	@DisplayName("PolicyService는 과도하게 긴 정규식 패턴을 차단한다")
+	void updateRedactionPolicyRejectsOverlyLongPattern() {
+		ProjectDto project = projectService.create("policy-redaction-pattern-length", "prod");
+		String longPattern = "a".repeat(513);
+
+		assertThatThrownBy(() -> policyService.updateRedactionPolicy(
+			project.id(),
+			new PolicyService.RedactionPolicyCommand(
+				true,
+				List.of(new PolicyService.RedactionRuleCommand("too-long", longPattern, "[MASKED]"))
+			)
+		))
+			.isInstanceOf(BadRequestException.class)
+			.hasMessage("rules[0].pattern must be at most 512 characters");
+	}
 }


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - Alert audit 로그에 프로젝트별 retention 상한을 도입했습니다.
  - Policy redaction regex에 패턴 길이 상한 검증을 추가했습니다.
  - 관련 단위/계약 테스트와 T-10 세션 노트를 추가했습니다.
- 왜 필요한가:
  - `docs/specs/2026-03-03-mvp-v1-work-unit-bootstrap.md`의 T-10 완료 조건(신뢰성 하드닝 + 필수 게이트 종료)을 충족하기 위해 필요합니다.

## 연결 이슈
- Closes #28

## 범위 점검
- 포함:
  - `AlertService` audit retention 상한 적용
  - `PolicyService` regex 길이 검증 적용
  - Alert/Policy 테스트 보강
  - `docs/sessions/2026-03-03-T-10.md` 작성
- 제외:
  - 외부 DB 영속화 전환
  - Slack/SMTP 실제 발송 재시도/큐 처리
  - 비밀값 암호화 저장소 전면 전환

## 주요 변경 사항
- `AlertService`
  - 기본 retention 상수(`DEFAULT_MAX_AUDIT_LOGS_PER_PROJECT = 5000`) 도입
  - audit append 시 상한 초과분(가장 오래된 로그) 제거 로직 추가
- `PolicyService`
  - regex 패턴 길이 상한(`MAX_REGEX_PATTERN_LENGTH = 512`) 검증 추가
- 테스트
  - `AlertServiceTest`: retention 상한 유지 시나리오 추가
  - `PolicyServiceTest`: 과도한 패턴 길이 차단 시나리오 추가
  - `PolicyEndpointsContractTest`: 긴 패턴 요청 400 응답 계약 추가

## TDD 근거
- RED:
  - `./gradlew test --tests "*AlertServiceTest" --tests "*PolicyServiceTest" --tests "*PolicyEndpointsContractTest"`
  - `AlertService` 테스트용 생성자 부재로 `compileTestJava` 실패
- GREEN:
  - 동일 테스트 명령 PASS
  - `./gradlew check` PASS
  - `./gradlew test` PASS
  - `./gradlew build` PASS
- REFACTOR:
  - AlertService 생성자 경계(기본/테스트용) 분리
  - regex guard 상수화로 검증 의도 명확화

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC1 -> `./gradlew test --tests "*AlertServiceTest"` -> PASS
- AC2 -> `./gradlew test --tests "*PolicyServiceTest" --tests "*PolicyEndpointsContractTest"` -> PASS
- AC3 -> `./gradlew check && ./gradlew test && ./gradlew build` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - pending
- codex:
  - pending

## 리스크 / 롤백
- 확인된 리스크:
  - 설정/로그는 여전히 in-memory라 재시작 시 유실될 수 있습니다.
  - regex 길이 제한은 1차 방어이며 모든 ReDoS 패턴을 완전 차단하지는 않습니다.
- 롤백 계획:
  - 본 PR revert 시 retention/regex guard 변경만 제거되어 이전 동작으로 복귀 가능합니다.

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-11에서 자동 리뷰(codex/coderabbitai) 코멘트를 수집/반영하고 merge readiness를 마무리합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트별 감사 로그 상한선 추가: 상한선 초과 시 오래된 로그가 자동으로 제거됩니다.
  * 정규식 패턴 길이 제한 추가: 리다이렉션 정책의 정규식 패턴을 최대 512자로 제한합니다.

* **테스트**
  * 감사 로그 보존 동작 및 정규식 패턴 길이 검증을 위한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->