### PR TITLE
[WU-12] T-12 보안/검증/OAuth2 의존성 및 기본 보안 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docs/sessions/2026-03-04-T-12.md
+++ b/docs/sessions/2026-03-04-T-12.md
@@ -1,0 +1,94 @@
+# Session Task Note - T-12
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #30
+- Branch: `feature/30-t12-security-baseline`
+- Task ID: T-12
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - Spring Security/Validation/OAuth2 starter 의존성을 추가한다.
+  - SecurityFilterChain 기본 정책(`/healthz`, `/readyz`, OAuth callback 공개 + 나머지 보호)을 도입한다.
+  - 인증/인가 실패 응답을 OpenAPI `ErrorResponse` 형태(`ApiErrorResponse`)로 통일한다.
+  - 보안 테스트 및 계약 회귀 테스트를 통과시킨다.
+- Do not do now:
+  - 컨트롤러 수동 bearer 검증 제거(T-13).
+  - OAuth state TTL/재사용 방지 고도화(T-15).
+  - 영속화/암호화 저장소 전환(T-21).
+- Done means:
+  - `build.gradle`에 보안/검증/OAuth2 starter가 반영된다.
+  - 보호 엔드포인트 무인증 요청이 JSON 파싱 이전에 401로 차단된다.
+  - 기존 `*EndpointsContractTest` 회귀 없이 통과한다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction` -> `openapi` -> `architecture-guardrails` -> workflow -> active spec 순으로 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - In scope의 OpenAI/Gemini 계정 관리, 정책/보안 기반, 운영 안정화 범위에 해당.
+- AC-to-rule mapping to execute:
+  - AC1 -> Static -> `rg -n "spring-boot-starter-security|spring-boot-starter-validation|spring-boot-starter-oauth2-client|spring-boot-starter-oauth2-resource-server" build.gradle` -> PASS
+  - AC1/AC2 -> Integration/Regression -> `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` -> PASS
+  - AC1 -> Build/Test -> `./gradlew check && ./gradlew test` -> PASS
+  - AC1 -> Build -> `./gradlew build` (의존성/보안 설정 변경) -> PASS
+
+## 2. Plan (Short)
+1. 보안 경계 동작을 RED 테스트(`SecurityEndpointsIntegrationTest`)로 먼저 고정한다.
+2. starter 추가 + SecurityFilterChain/인증 필터/보안 에러 핸들링을 최소 구현한다.
+3. 계약 회귀 및 필수/조건부 게이트를 실행해 완료 조건을 검증한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*Security*Test"` 실행 시
+    - `보호 엔드포인트는 무인증 요청에서 JSON 파싱 전에 401로 차단한다` 실패
+    - 기대: 401, 실제: 400
+- GREEN pass output summary:
+  - `./gradlew test --tests "*Security*Test"` PASS
+  - `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` PASS
+  - `./gradlew check test build` PASS
+- REFACTOR summary:
+  - `BearerAuthenticationFilter`의 공개 경로 판별을 deprecated matcher 대신 URI 기반 패턴 매칭으로 정리.
+  - `IncidentControllerTest`에 보안 설정 import를 명시해 slice test의 보안 경계가 실제 구성과 일치하도록 정리.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `build.gradle`
+  - `src/main/java/com/logcopilot/common/security/SecurityConfiguration.java`
+  - `src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java`
+  - `src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java`
+  - `src/test/java/com/logcopilot/incident/IncidentControllerTest.java`
+- Why this approach:
+  - T-13(수동 인증 제거) 이전 단계이므로 기존 컨트롤러 로직을 최대한 유지하면서, 필터 체인으로 최소 보안 경계를 먼저 세웠다.
+  - 인증 실패를 필터 체인에서 선차단해 malformed body 우회(400 먼저 발생) 문제를 제거했다.
+  - OAuth callback 공개 경로를 명시적으로 허용해 OpenAPI 계약을 유지했다.
+
+## 5. Verification
+- Commands:
+  - `rg -n "spring-boot-starter-security|spring-boot-starter-validation|spring-boot-starter-oauth2-client|spring-boot-starter-oauth2-resource-server" build.gradle`
+  - `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"`
+  - `./gradlew check test build`
+- Results:
+  - 모든 명령 PASS.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Self-review (보안 경계/회귀/계약 준수 중심).
+- Findings:
+  - 현재 인증은 Bearer 형식 검증 수준이며 토큰의 실제 검증/권한 분리는 아직 미완료.
+  - ingestToken/bearerAuth의 정책 분리는 T-13에서 수행 필요.
+- Resolution:
+  - T-12 범위에서는 기본 보안 체인과 표준 에러 응답을 우선 완료.
+  - 토큰 검증 고도화/인가 정책 세분화는 다음 태스크에서 진행.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - 토큰 내용 검증/권한 레벨 판별은 아직 구현되지 않았다.
+  - 컨트롤러의 수동 bearer 검증 호출이 남아 있어 중복 검증 경로가 존재한다.
+- Next task ID:
+  - T-13
+- Suggested first check for next session:
+  - `BearerTokenValidator` 직접 호출 지점을 제거하고 `bearerAuth`/`ingestToken` 분리 정책을 SecurityFilterChain으로 이전할 것.

--- a/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
+++ b/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.logcopilot.common.security;
+
+import com.logcopilot.common.auth.BearerTokenValidator;
+import com.logcopilot.common.error.UnauthorizedException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class BearerAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final Pattern OAUTH_CALLBACK_PATH = Pattern.compile("^/v1/projects/[^/]+/llm-oauth/[^/]+/callback$");
+
+	private final BearerTokenValidator bearerTokenValidator;
+	private final AuthenticationEntryPoint authenticationEntryPoint;
+
+	public BearerAuthenticationFilter(
+		BearerTokenValidator bearerTokenValidator,
+		AuthenticationEntryPoint authenticationEntryPoint
+	) {
+		this.bearerTokenValidator = bearerTokenValidator;
+		this.authenticationEntryPoint = authenticationEntryPoint;
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		boolean publicEndpoint = "/healthz".equals(path)
+			|| "/readyz".equals(path)
+			|| OAUTH_CALLBACK_PATH.matcher(path).matches();
+		return HttpMethod.OPTIONS.matches(request.getMethod()) || publicEndpoint;
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		try {
+			String token = bearerTokenValidator.validate(request.getHeader(HttpHeaders.AUTHORIZATION));
+			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+				token,
+				token,
+				List.of(new SimpleGrantedAuthority("ROLE_API"))
+			);
+			authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			filterChain.doFilter(request, response);
+		} catch (UnauthorizedException exception) {
+			SecurityContextHolder.clearContext();
+			authenticationEntryPoint.commence(
+				request,
+				response,
+				new BadCredentialsException(exception.getMessage(), exception)
+			);
+		}
+	}
+}

--- a/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
+++ b/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
@@ -1,0 +1,92 @@
+package com.logcopilot.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logcopilot.common.api.ApiErrorResponse;
+import com.logcopilot.common.auth.BearerTokenValidator;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+@Configuration
+public class SecurityConfiguration {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(
+		HttpSecurity http,
+		BearerAuthenticationFilter bearerAuthenticationFilter,
+		AuthenticationEntryPoint authenticationEntryPoint,
+		AccessDeniedHandler accessDeniedHandler
+	) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(Customizer.withDefaults())
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(authenticationEntryPoint)
+				.accessDeniedHandler(accessDeniedHandler))
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers("/healthz", "/readyz").permitAll()
+				.requestMatchers("/v1/projects/*/llm-oauth/*/callback").permitAll()
+				.anyRequest().authenticated())
+			.addFilterBefore(bearerAuthenticationFilter, AnonymousAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	@Bean
+	public BearerAuthenticationFilter bearerAuthenticationFilter(
+		BearerTokenValidator bearerTokenValidator,
+		AuthenticationEntryPoint authenticationEntryPoint
+	) {
+		return new BearerAuthenticationFilter(bearerTokenValidator, authenticationEntryPoint);
+	}
+
+	@Bean
+	public AuthenticationEntryPoint authenticationEntryPoint(ObjectMapper objectMapper) {
+		return (request, response, exception) -> writeError(
+			response,
+			HttpStatus.UNAUTHORIZED,
+			ApiErrorResponse.of("unauthorized", "Missing or invalid bearer token"),
+			objectMapper
+		);
+	}
+
+	@Bean
+	public AccessDeniedHandler accessDeniedHandler(ObjectMapper objectMapper) {
+		return (request, response, exception) -> writeError(
+			response,
+			HttpStatus.FORBIDDEN,
+			ApiErrorResponse.of("forbidden", "Access denied"),
+			objectMapper
+		);
+	}
+
+	private void writeError(
+		HttpServletResponse response,
+		HttpStatus status,
+		ApiErrorResponse payload,
+		ObjectMapper objectMapper
+	) throws IOException {
+		if (response.isCommitted()) {
+			return;
+		}
+
+		response.setStatus(status.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		objectMapper.writeValue(response.getOutputStream(), payload);
+	}
+}

--- a/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
+++ b/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
@@ -34,6 +34,7 @@ class SecurityEndpointsIntegrationTest {
 	@Test
 	@DisplayName("OAuth callback 엔드포인트는 인증 없이 접근 가능하다")
 	void oauthCallbackIsAccessibleWithoutAuthorization() throws Exception {
+		// 이 테스트는 보안 경계 확인이 목적이라, 인증 실패(401)만 아니면 허용한다.
 		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", "project-1", "openai")
 				.queryParam("code", "oauth-code")
 				.queryParam("state", "oauth-state"))

--- a/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
+++ b/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.logcopilot.common.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityEndpointsIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("공개 엔드포인트 healthz/readyz 는 인증 없이 접근 가능하다")
+	void publicEndpointsAreAccessibleWithoutAuthorization() throws Exception {
+		mockMvc.perform(get("/healthz"))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(get("/readyz"))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("OAuth callback 엔드포인트는 인증 없이 접근 가능하다")
+	void oauthCallbackIsAccessibleWithoutAuthorization() throws Exception {
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", "project-1", "openai")
+				.queryParam("code", "oauth-code")
+				.queryParam("state", "oauth-state"))
+			.andExpect(status().is4xxClientError())
+			.andExpect(jsonPath("$.error.code", not("unauthorized")));
+	}
+
+	@Test
+	@DisplayName("보호 엔드포인트는 무인증 요청에서 JSON 파싱 전에 401로 차단한다")
+	void protectedEndpointsReturn401BeforeJsonBindingWhenUnauthorized() throws Exception {
+		mockMvc.perform(post("/v1/projects")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"broken\","))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.error.code").value("unauthorized"))
+			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
+	}
+}

--- a/src/test/java/com/logcopilot/incident/IncidentControllerTest.java
+++ b/src/test/java/com/logcopilot/incident/IncidentControllerTest.java
@@ -1,6 +1,7 @@
 package com.logcopilot.incident;
 
 import com.logcopilot.common.auth.BearerTokenValidator;
+import com.logcopilot.common.security.SecurityConfiguration;
 import com.logcopilot.incident.domain.AnalysisReport;
 import com.logcopilot.incident.domain.Hypothesis;
 import com.logcopilot.incident.domain.IncidentDetail;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -27,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(IncidentController.class)
+@Import(SecurityConfiguration.class)
 class IncidentControllerTest {
 
 	@Autowired

--- a/src/test/java/com/logcopilot/incident/IncidentControllerTest.java
+++ b/src/test/java/com/logcopilot/incident/IncidentControllerTest.java
@@ -8,6 +8,7 @@ import com.logcopilot.incident.domain.IncidentDetail;
 import com.logcopilot.incident.domain.IncidentStatus;
 import com.logcopilot.incident.domain.ReanalyzeAcceptedResult;
 import com.logcopilot.project.ProjectService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,11 @@ class IncidentControllerTest {
 
 	@MockBean
 	private BearerTokenValidator bearerTokenValidator;
+
+	@BeforeEach
+	void setUpAuthenticationStub() {
+		when(bearerTokenValidator.validate("Bearer token")).thenReturn("token");
+	}
 
 	@Test
 	@DisplayName("IncidentController는 incident의 project가 없으면 상세 조회에 404를 반환한다")


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - Spring Security/Validation/OAuth2 starter를 추가했습니다.
  - SecurityFilterChain과 BearerAuthenticationFilter를 도입해 공개/보호 엔드포인트 경계를 설정했습니다.
  - 인증/인가 실패 응답을 `ApiErrorResponse` 형식으로 통일했습니다.
  - 보안 통합 테스트와 기존 계약 테스트 회귀를 통과시켰습니다.
- 왜 필요한가:
  - T-12 AC(보안 기본 구성 + 회귀 없음)를 충족하고, 무인증 요청이 JSON 바인딩 우회로 400을 먼저 내는 문제를 401 선차단으로 교정하기 위해 필요합니다.

## 연결 이슈
- Closes #30

## 범위 점검
- 포함:
  - `build.gradle` 보안/검증/OAuth2 의존성 추가
  - `SecurityConfiguration`, `BearerAuthenticationFilter` 추가
  - `SecurityEndpointsIntegrationTest` 추가
  - `IncidentControllerTest` 보안 설정 반영
  - 세션 노트 `docs/sessions/2026-03-04-T-12.md` 작성
- 제외:
  - 컨트롤러 수동 bearer 검증 제거(T-13)
  - bearerAuth/ingestToken 세분화(T-13)
  - OAuth state TTL/재사용 방지 고도화(T-15)

## 주요 변경 사항
- 변경 1
  - 공개 경로: `/healthz`, `/readyz`, `/v1/projects/*/llm-oauth/*/callback`
  - 보호 경로: 그 외 전체
- 변경 2
  - 인증 실패: 401 `{"error":{"code":"unauthorized","message":"Missing or invalid bearer token"}}`
  - 인가 실패: 403 `{"error":{"code":"forbidden","message":"Access denied"}}`

## TDD 근거
- RED:
  - `./gradlew test --tests "*Security*Test"`
  - `보호 엔드포인트는 무인증 요청에서 JSON 파싱 전에 401로 차단한다` 실패(기대 401, 실제 400)
- GREEN:
  - `./gradlew test --tests "*Security*Test"` PASS
  - `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` PASS
- REFACTOR:
  - 공개 경로 판별 로직을 URI 패턴 기반으로 정리하고, IncidentController WebMvcTest를 실제 보안 구성과 일치시켰습니다.

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC1 -> `rg -n "spring-boot-starter-security|spring-boot-starter-validation|spring-boot-starter-oauth2-client|spring-boot-starter-oauth2-resource-server" build.gradle` -> PASS
- AC1/AC2 -> `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 대기 중
- codex:
  - 대기 중

## 리스크 / 롤백
- 확인된 리스크:
  - 현재는 Bearer 형식 검증 중심이며 토큰 실검증/권한 분리는 T-13에서 이어서 처리해야 합니다.
- 롤백 계획:
  - 본 PR revert 시 기존 수동 bearer 검증 기반 동작으로 즉시 복구 가능합니다.

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-13: 컨트롤러 수동 인증 제거 + bearerAuth/ingestToken 인증/인가 일원화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Bearer 토큰 기반 API 인증 시스템 도입하여 보안 강화
  * OAuth2 클라이언트 및 리소스 서버 프로토콜 지원 추가
  * API 엔드포인트 인증 요구 - 헬스 체크 및 OAuth 콜백 엔드포인트는 공개 유지
  * 미인증(401) 및 접근 거부(403) 응답에 대한 표준화된 오류 처리 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->