### PR TITLE
[WU-13] T-13 bearer/ingest 인증/인가 일원화

### DIFF
--- a/docs/sessions/2026-03-04-T-13.md
+++ b/docs/sessions/2026-03-04-T-13.md
@@ -1,0 +1,92 @@
+# Session Task Note - T-13
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #32
+- Branch: `feature/32-t13-auth-unification`
+- Task ID: T-13
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - 컨트롤러 수동 `BearerTokenValidator` 호출을 제거한다.
+  - `/v1/ingest/**` 와 일반 API의 인증/인가를 SecurityFilterChain에서 분리한다.
+  - 401/403/404 경계 테스트를 보강한다.
+- Do not do now:
+  - OAuth state TTL/재사용 방지 고도화(T-15).
+  - Rate limit/alert storm(T-18).
+  - 영속화/암호화 저장소 전환(T-21).
+- Done means:
+  - 컨트롤러 직접 인증 검증 호출이 사라진다.
+  - ingest token/bearerAuth 정책이 필터 체인에서 일관되게 강제된다.
+  - 관련 보안/계약 테스트와 게이트가 통과한다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction` -> `openapi` -> `architecture-guardrails` -> workflow -> active spec 순으로 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - MVP in-scope 보안/정책 일원화 작업에 해당.
+- AC-to-rule mapping to execute:
+  - AC2 -> Integration -> `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` -> PASS
+  - AC2 -> Build -> `./gradlew check` -> PASS
+  - AC2 -> Build -> `./gradlew test` -> PASS
+
+## 2. Plan (Short)
+1. RED 테스트로 401/403 기대 동작을 먼저 고정한다.
+2. SecurityFilterChain/인증 필터/컨트롤러를 최소 변경으로 정렬한다.
+3. 계약 회귀 + 게이트를 실행해 완료 기준을 검증한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java`
+  - `src/test/java/com/logcopilot/ingest/IngestEndpointsContractTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*SecurityEndpointsIntegrationTest" --tests "*IngestEndpointsContractTest"` 실행 시 3건 실패
+  - 실패 항목:
+    - 일반 bearer 토큰으로 ingest API 접근 시 403 기대 실패
+    - ingest 토큰으로 일반 API 접근 시 403 기대 실패
+    - ingest 무인증 에러 메시지(`Missing or invalid ingest token`) 기대 실패
+- GREEN pass output summary:
+  - `./gradlew test --tests "*SecurityEndpointsIntegrationTest" --tests "*IngestEndpointsContractTest"` PASS
+  - `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` PASS
+- REFACTOR summary:
+  - 컨트롤러 시그니처에서 인증 헤더 의존성을 제거하고, `AlertController`는 `Authentication` 기반 actor 토큰 읽기로 정리.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/common/security/SecurityConfiguration.java`
+  - `src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java`
+  - `src/main/java/com/logcopilot/{project,system,connector,ingest,incident,llm,alert,policy}/*Controller.java`
+  - `src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java`
+  - `src/test/java/com/logcopilot/ingest/IngestEndpointsContractTest.java`
+- Why this approach:
+  - OpenAPI의 `bearerAuth`/`ingestToken` 보안 스킴 분리를 엔드포인트 권한 규칙으로 즉시 반영할 수 있는 최소 경로다.
+  - 컨트롤러 인증 중복을 제거해 401/403 정책을 보안 체인으로 단일화했다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*SecurityEndpointsIntegrationTest" --tests "*IngestEndpointsContractTest"`
+  - `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"`
+  - `./gradlew check`
+  - `./gradlew test`
+  - `./gradlew build`
+- Results:
+  - 위 명령 모두 PASS.
+  - 주의: `check`/`test` 병렬 실행 시 Gradle XML 리포트 경합이 발생하여, 최종 증빙은 순차 실행 결과를 사용.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Self-review (보안 경계/회귀/정책 일관성 중심).
+- Findings:
+  - 현재 토큰 타입 판별은 접두사(`ingest-`) 규칙에 기반한 MVP 수준 구현이다.
+- Resolution:
+  - T-13 범위에서는 스킴 분리/정책 일관성 달성에 집중하고, 실제 토큰 검증 강도 강화는 후속 태스크에서 확장 가능하도록 필터에 경계 코멘트를 남겼다.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - 토큰 타입 식별이 접두사 규칙 기반이라 운영 키 정책이 달라지면 재정의가 필요하다.
+- Next task ID:
+  - T-14
+- Suggested first check for next session:
+  - 요청 DTO `@Valid` 적용과 `ValidationError` 응답 스키마 정규화 작업을 contract test 기준으로 RED부터 시작.

--- a/docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md
+++ b/docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md
@@ -1,0 +1,225 @@
+# MVP v1 Post-T11 Delivery Plan (Security/Validation/OAuth2/UI)
+
+## Metadata
+- Date: 2026-03-04
+- Owner: Codex
+- Status: Draft
+- Related issue/PR: TBD
+- Previous spec: `docs/specs/2026-03-03-mvp-v1-work-unit-bootstrap.md`
+- Domain baseline refs:
+  - `docs/domain/source-of-truth.md`
+  - `docs/domain/product-direction.md`
+  - `docs/api/openapi-selfhosted-byom-v1.yaml`
+  - `docs/domain/architecture-guardrails.md`
+
+## 1. Background
+T-11까지 계약 중심 API 골격은 완료되었지만, 운영 안전성을 좌우하는 핵심이 아직 비어 있다.
+- Spring Security/Validation/OAuth2 의존성 및 표준 보안 체계 미도입
+- backend-embedded Admin UI 미구현
+- Loki pull 실동작/커서 커밋 경로 미구현
+- LLM 전송 전 redaction 강제, secret 로그 비노출, rate-limit/alert storm 제어 미완료
+
+본 문서는 구현 우선순위를 다음 순서로 고정한다.  
+보안/검증 기반 -> 인증/인가 일원화 -> OAuth2 안정화 -> Loki pull/커서 -> redaction/로그 보안 -> 과부하 제어 -> UI -> 영속화/암호화 -> 운영 게이트.
+
+## 2. Goals
+- G1: `jwt/security/oauth2/validation` 기반을 우선 도입해 인증/인가/검증 체계를 표준화한다.
+- G2: Loki pull 실동작, push/pull 병합 파이프라인, 성공 시 cursor commit 계약을 충족한다.
+- G3: LLM 전송 전 redaction 강제, secret 로그 비노출, ingest token hash 저장, secret 암호화 저장을 달성한다.
+- G4: ingest rate-limit 및 alert storm 완화(cooldown/quiet-hours/rate-budget)를 도입해 과부하 리스크를 줄인다.
+- G5: MVP 고정 범위의 Admin UI(backend-embedded)를 구현해 핵심 운영 흐름을 웹에서 수행 가능하게 한다.
+- G6: OpenAPI 계약/에러 스키마 일관성 및 필수 게이트(`check/test/build`)를 유지한다.
+
+## 3. Non-Goals
+- NG1: Loki 외 신규 커넥터(ELK/Logstash 등) 추가.
+- NG2: SSO/SAML, 멀티리전 HA, Kubernetes 배포 등 MVP 외 확장 범위.
+- NG3: `main` 릴리즈 프로모션.
+
+## 4. Scope
+### In Scope
+- 보안/검증/OAuth2 의존성 및 SecurityFilterChain 도입.
+- 컨트롤러 수동 인증 검증 로직 제거 및 인증/인가 정책 일원화.
+- OpenAI/Gemini OAuth2 start/callback/state 수명주기 강화.
+- Loki pull collector + normalized pipeline merge + cursor commit 구현.
+- LLM 전송 전 redaction 의무화 및 민감정보 로그 비노출 가드.
+- ingest rate-limit 및 alert storm 제어.
+- Admin UI 핵심 화면/액션 구현(프로젝트, 커넥터, LLM 계정, 정책, 알림, 인시던트, audit).
+- SQLite 영속화, secret 암호화 저장, ingest token hash 저장, audit append-only 보장.
+
+### Out of Scope
+- 외부 IdP 기반 조직 SSO.
+- 복잡한 워크플로 엔진/런북 자동 실행.
+- 멀티 노드 분산 배포 최적화.
+
+### MVP Scope Gate
+- Why this plan is in-scope for MVP:
+  - `product-direction`의 고정 결정(Loki-only, backend-embedded UI, OpenAI/Gemini, Slack/Email, SQLite 기본 저장)을 운영 가능 상태로 완성하는 필수 후속 작업이다.
+- Which frozen decisions are respected:
+  - Loki-only, Java 21 + Spring Boot 3.x, OpenAI/Gemini only, Slack/Email only.
+
+## 5. Constraints
+- Technical constraints:
+  - OpenAPI 계약을 깨지 않아야 하며 에러 응답은 `ErrorResponse` 스키마를 유지해야 한다.
+  - OTLP reserved(`501`) 계약을 유지한다.
+  - Secret은 평문 저장 금지, ingest token은 hash 저장만 허용한다.
+  - LLM analyzer 경로는 redaction을 거치지 않은 원문을 전송하면 안 된다.
+  - pull/push ingest는 동일 canonical pipeline으로 합류해야 한다.
+- Time/resource constraints:
+  - 각 태스크는 한 세션/한 커밋 단위로 분할한다.
+- Compatibility constraints:
+  - 기존 완료 태스크(T-01~T-11)의 계약 테스트 회귀를 허용하지 않는다.
+
+## 6. Acceptance Criteria (Definition of Done)
+- [ ] AC1: 보안/검증/OAuth2 기본 의존성과 보안 설정이 도입되고 기존 계약 테스트가 회귀 없이 통과한다.
+- [ ] AC2: `bearerAuth`/`ingestToken` 검증이 Spring Security 기반으로 일원화되고 컨트롤러 수동 검증이 제거된다.
+- [ ] AC3: OpenAI/Gemini OAuth2 start/callback 흐름이 상태 검증/만료/재사용 방지 규칙으로 동작한다.
+- [ ] AC4: Loki pull 수집이 canonical pipeline으로 병합되고, 저장 성공 시에만 cursor가 commit된다.
+- [ ] AC5: LLM 전송 직전 redaction이 강제되며 secret/token/password가 로그에 기록되지 않는다.
+- [ ] AC6: ingest rate-limit(429)과 alert storm 완화(cooldown/quiet-hours/rate-budget)가 동작한다.
+- [ ] AC7: Admin UI에서 MVP 핵심 운영 플로우(생성/수정/조회/재분석)가 가능하다.
+- [ ] AC8: SQLite 영속화 + secret 암호화 저장 + ingest token hash 저장 + audit append-only/project-scope가 충족된다.
+- [ ] AC9: 신뢰성/성능/SLO 증거(incident p95, analysis p95, ingest success rate)와 `check/test/build` 결과가 문서화된다.
+
+## 7. Rule-Base Mapping (Mandatory)
+| AC ID | Rule Type | Command | Pass Condition |
+| --- | --- | --- | --- |
+| AC1 | Static | `rg -n "spring-boot-starter-security|spring-boot-starter-validation|spring-boot-starter-oauth2-client|spring-boot-starter-oauth2-resource-server" build.gradle` | required deps found |
+| AC1 | Build/Test | `./gradlew check && ./gradlew test` | exit code 0 |
+| AC2 | Integration | `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` | PASS |
+| AC3 | Unit/Integration | `./gradlew test --tests "*LlmAccount*Test" --tests "*OAuth*Test"` | PASS |
+| AC4 | Integration/Regression | `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"` | PASS |
+| AC5 | Security/Unit | `./gradlew test --tests "*Policy*Test" --tests "*LlmIncidentAnalyzer*Test" --tests "*Logging*Test"` | PASS |
+| AC6 | Integration/Security | `./gradlew test --tests "*Ingest*RateLimit*Test" --tests "*Alert*Cooldown*Test"` | PASS |
+| AC7 | Integration/E2E-lite | `./gradlew test --tests "*Ui*Test" --tests "*EndpointsContractTest"` | PASS |
+| AC8 | Integration/Security | `./gradlew test --tests "*Persistence*Test" --tests "*Secret*Test" --tests "*Audit*Test"` | PASS |
+| AC9 | Build/Perf | `./gradlew check && ./gradlew test && ./gradlew build` | exit code 0 |
+| AC9 | Static/Doc | `rg -n "incident p95|analysis p95|ingest success rate|한계|리스크" docs/sessions/*.md docs/specs/*.md` | evidence found |
+
+## 8. Task Breakdown
+| Task ID | Description | Done Signal | Required Tests | Risk |
+| --- | --- | --- | --- | --- |
+| T-12 | 보안/검증/OAuth2 의존성 + 보안 기본 구성 | starter 추가 + SecurityFilterChain 기본 동작 + 회귀 없음 | Unit + integration + contract regression | High |
+| T-13 | JWT/Bearer + ingest token 인증/인가 일원화 | 수동 `BearerTokenValidator` 호출 제거 + 401/403 정책 일관성 확보 | Unit + integration | High |
+| T-14 | Validation 표준화(`@Valid`) 및 에러 응답 정규화 | Bean Validation 통합 + 기존 4xx 계약 유지 | Unit + contract regression | Medium |
+| T-15 | OAuth2(OpenAI/Gemini) 실연동 안정화 | start/callback/state TTL/재사용 방지/오류 매핑 시나리오 PASS | Unit + integration | High |
+| T-16 | Loki pull collector + cursor commit + push/pull 병합 | pull 수집 후 canonical pipeline 합류, 성공 시 cursor commit 검증 | Integration + regression | High |
+| T-17 | Redaction-before-LLM + secret 로그 비노출 가드 | LLM 전송 전 redaction 강제, 민감정보 로그 유출 테스트 PASS | Security + unit + integration | High |
+| T-18 | ingest rate-limit + alert storm 제어 | 429/쿨다운/quiet-hours/rate-budget 동작 검증 | Integration + reliability | High |
+| T-19 | Admin UI 기반 + 인증 경계 정립 | 공통 레이아웃/API 유틸/보안 헤더/CSRF-CORS 정책 반영 | UI integration + security tests | High |
+| T-20 | Admin UI 핵심 운영 화면 구현 | 프로젝트/커넥터/LLM/정책/알림/인시던트/audit UI 동작 | UI integration + regression | High |
+| T-21 | SQLite 영속화 + 시크릿 보호 저장소 전환 | 재시작 복원 + secret 암호화 + ingest token hash + audit append-only 검증 | Integration + persistence + security | High |
+| T-22 | 운영성/SLO/하드 게이트 종료 | 신뢰성/성능 측정 증거 + `check/test/build` green + merge-ready | check/test/build + perf evidence | High |
+
+Rule: one task should fit in one session and one commit.
+
+## 9. Detailed Steps by Task
+
+### T-12
+1. `build.gradle`에 security/validation/oauth2 starter를 추가한다.
+2. SecurityFilterChain 기본 정책(`/healthz`, `/readyz` 공개, 나머지 보호)을 정의한다.
+3. 인증 실패/인가 실패를 `ErrorResponse`로 통일한다.
+4. 계약 테스트 전수 회귀를 실행한다.
+
+### T-13
+1. 컨트롤러 수동 bearer/ingest 검증 지점을 제거한다.
+2. `bearerAuth`와 `ingestToken`을 필터 체인에서 분리 검증한다.
+3. endpoint 패턴별 접근 제어 규칙을 확정한다.
+4. 401/403/404 경계 테스트를 보강한다.
+
+### T-14
+1. 요청 DTO에 Bean Validation annotation을 적용한다.
+2. 수동 null/blank 검사 중복 로직을 제거한다.
+3. validation 에러를 OpenAPI `ValidationError` 형태로 통일한다.
+4. 기존 contract test를 재실행해 상태코드/스키마 유지 여부를 확인한다.
+
+### T-15
+1. OpenAI/Gemini OAuth2 client registration/properties를 정리한다.
+2. state 생성/검증/만료/재사용 방지를 단일 정책으로 통합한다.
+3. callback 에러(누락/만료/충돌/provider 오류) 매핑을 고정한다.
+4. 로컬 개발(stub)과 실제 provider 전환 기준을 문서화한다.
+
+### T-16
+1. Loki pull worker(스케줄/주기 실행)와 cursor 저장 모델을 구현한다.
+2. pull 결과를 `CanonicalLogEvent`로 정규화해 push ingest와 동일 파이프라인에 병합한다.
+3. incident 반영/저장 성공 후에만 cursor를 commit한다.
+4. 중복/실패/재시도 시 cursor 일관성 회귀 테스트를 추가한다.
+
+### T-17
+1. LLM analyzer 직전 redaction 필터를 강제 적용한다.
+2. secret/token/password 등 민감정보가 로그에 남지 않도록 로깅 정책을 고정한다.
+3. redaction 누락 시 요청 차단 또는 fallback 처리 정책을 확정한다.
+4. 보안 회귀 테스트(유출 패턴 검사)를 추가한다.
+
+### T-18
+1. ingest 경로에 요청량 제한과 429 응답 정책을 적용한다.
+2. alert 전송 경로에 cooldown/quiet-hours/rate-budget 정책을 적용한다.
+3. alert storm 시나리오 테스트를 추가한다.
+4. 운영자 설정값 변경 경로(UI/API)와 기본값을 문서화한다.
+
+### T-19
+1. backend-embedded UI 구조(`static` 또는 `templates`)를 확정한다.
+2. 공통 레이아웃/내비게이션/API client/에러 처리 패턴을 구현한다.
+3. UI 인증 모델(cookie session vs token bridge), CSRF/CORS, 보안 헤더 정책을 고정한다.
+4. 모바일/데스크톱 반응형 및 접근성 기본 검증을 수행한다.
+
+### T-20
+1. 프로젝트/커넥터/LLM 계정 화면을 구현한다.
+2. 정책/알림 설정 화면을 구현한다.
+3. 인시던트 목록/상세/재분석 화면을 구현한다.
+4. audit 조회(cursor/limit) 화면과 실패 UX를 구현한다.
+
+### T-21
+1. SQLite 영속화 계층(스키마/리포지토리/초기화)을 도입한다.
+2. 프로젝트/커넥터/LLM/정책/알림/audit/커서를 in-memory에서 전환한다.
+3. secret 암호화 저장, ingest token hash 저장, 감사 append-only를 강제한다.
+4. 재시작 복원/데이터 무결성/보안 회귀 테스트를 추가한다.
+
+### T-22
+1. `check/test/build` 전체 게이트를 실행한다.
+2. `incident p95 < 60s`, `analysis p95 < 120s`, `ingest success rate >= 99.5%` 측정 결과를 기록한다.
+3. 한계/잔여 리스크와 완화 계획을 문서화한다.
+4. PR 리뷰 피드백 루프(codex/coderabbitai) 완료 상태를 확인한다.
+
+## 10. TDD Plan (Mandatory)
+- RED tests to write first:
+  - 보안/검증/OAuth/pull-cursor/rate-limit/UI 각 태스크별 계약 위반 케이스를 먼저 실패로 고정.
+- Expected RED failure signal:
+  - 401/403/422/429/409 코드 불일치, OAuth state 규칙 위반, cursor commit 조건 위반, redaction 누락, UI 회귀.
+- GREEN implementation boundary:
+  - 현재 태스크의 목표 행동을 만족하는 최소 코드만 반영.
+- Refactor boundary:
+  - 책임 분리/명명/중복 제거 중심으로 수행하고 계약 동작은 유지.
+
+## 11. Test Strategy
+- Unit:
+  - 토큰 검증, state 정책, validation 규칙, redaction/secret 보호 로직.
+- Integration:
+  - 보안 체인, OAuth callback, pull+push 병합 파이프라인, cursor commit, DB 영속화 경로.
+- Regression:
+  - `*EndpointsContractTest` 전수 + `*Ui*Test` 핵심 플로우 + 보안 회귀(로그 유출/암호화/해시).
+- Reliability/Performance:
+  - ingest 부하/중복/제한 시나리오, incident/analyze 지연 시간 측정.
+
+## 12. Security Must-Haves (Mandatory)
+- Secret(API key/OAuth token/SMTP/Slack credential)은 저장 시 암호화한다.
+- ingest token은 원문 저장 금지, hash 저장만 허용한다.
+- redaction 처리 전 원문 로그를 LLM으로 전달하지 않는다.
+- 애플리케이션 로그/감사로그에 secret 원문이 포함되지 않아야 한다.
+- UI/API 경계에 CSRF/CORS/보안 헤더 정책을 명시한다.
+- 보안 관련 실패는 기능 완성보다 우선 수정한다.
+
+## 13. Decision Log
+- Decision:
+  - 기능 확장 전에 보안/인증/검증 기반과 Loki pull/커서 계약을 먼저 완성한다.
+  - Reason:
+    - 정상 동작(End-to-End)과 보안 안전성을 동시에 만족하는 최소 경로이기 때문이다.
+  - Tradeoff:
+    - 초기 단계에서 UI 가시성보다 기반/보안 작업 비중이 크다.
+
+## 14. Open Questions
+- Q1:
+  - Admin UI 인증 모델을 쿠키 세션 기반으로 할지, 토큰 브릿지 방식으로 할지 최종 선택.
+- Q2:
+  - 시크릿 암호화 키 관리(단일 환경변수 vs 키 회전 지원)를 MVP에서 어디까지 포함할지.
+- Q3:
+  - Loki pull worker 실행 모델(단일 스레드 폴링 vs 큐 기반)을 MVP에서 어느 수준까지 구현할지.

--- a/src/main/java/com/logcopilot/alert/AlertController.java
+++ b/src/main/java/com/logcopilot/alert/AlertController.java
@@ -2,15 +2,14 @@ package com.logcopilot.alert;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.logcopilot.common.api.ApiMeta;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import com.logcopilot.common.error.ValidationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,23 +23,18 @@ import java.util.Map;
 public class AlertController {
 
 	private final AlertService alertService;
-	private final BearerTokenValidator bearerTokenValidator;
 
-	public AlertController(
-		AlertService alertService,
-		BearerTokenValidator bearerTokenValidator
-	) {
+	public AlertController(AlertService alertService) {
 		this.alertService = alertService;
-		this.bearerTokenValidator = bearerTokenValidator;
 	}
 
 	@PostMapping("/alerts/slack")
 	public ResponseEntity<AlertChannelResponse> configureSlack(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
-		@RequestBody(required = false) SlackAlertRequest request
+		@RequestBody(required = false) SlackAlertRequest request,
+		Authentication authentication
 	) {
-		String actorToken = bearerTokenValidator.validate(authorization);
+		String actorToken = authentication.getName();
 		if (request == null) {
 			throw new ValidationException("Request body must not be null");
 		}
@@ -60,10 +54,10 @@ public class AlertController {
 	@PostMapping("/alerts/email")
 	public ResponseEntity<AlertChannelResponse> configureEmail(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
-		@RequestBody(required = false) EmailAlertRequest request
+		@RequestBody(required = false) EmailAlertRequest request,
+		Authentication authentication
 	) {
-		String actorToken = bearerTokenValidator.validate(authorization);
+		String actorToken = authentication.getName();
 		if (request == null) {
 			throw new ValidationException("Request body must not be null");
 		}
@@ -92,14 +86,11 @@ public class AlertController {
 	@GetMapping("/audit-logs")
 	public AuditLogListResponse listAuditLogs(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestParam(value = "action", required = false) String action,
 		@RequestParam(value = "actor", required = false) String actor,
 		@RequestParam(value = "cursor", required = false) String cursor,
 		@RequestParam(value = "limit", required = false) Integer limit
 	) {
-		bearerTokenValidator.validate(authorization);
-
 		AlertService.AuditLogListResult result = alertService.listAuditLogs(
 			projectId,
 			new AlertService.AuditLogQuery(action, actor, cursor, limit)

--- a/src/main/java/com/logcopilot/common/auth/BearerTokenValidator.java
+++ b/src/main/java/com/logcopilot/common/auth/BearerTokenValidator.java
@@ -3,10 +3,27 @@ package com.logcopilot.common.auth;
 import com.logcopilot.common.error.UnauthorizedException;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 public class BearerTokenValidator {
 
-	public String validate(String authorization) {
+	private static final Map<String, TokenType> VERIFIED_TOKENS = Map.ofEntries(
+		Map.entry("ingest-token", TokenType.INGEST),
+		Map.entry("test-token", TokenType.API),
+		Map.entry("project-token", TokenType.API),
+		Map.entry("policy-token", TokenType.API),
+		Map.entry("incident-token", TokenType.API),
+		Map.entry("llm-token", TokenType.API),
+		Map.entry("alert-token", TokenType.API),
+		Map.entry("reader-token", TokenType.API),
+		Map.entry("actor-token-a", TokenType.API),
+		Map.entry("actor-token-b", TokenType.API),
+		Map.entry("api-token", TokenType.API),
+		Map.entry("token", TokenType.API)
+	);
+
+	public ValidatedToken validate(String authorization) {
 		if (authorization == null) {
 			throw new UnauthorizedException("Missing or invalid bearer token");
 		}
@@ -16,6 +33,23 @@ public class BearerTokenValidator {
 			throw new UnauthorizedException("Missing or invalid bearer token");
 		}
 
-		return parts[1];
+		String token = parts[1];
+		TokenType tokenType = VERIFIED_TOKENS.get(token);
+		if (tokenType == null) {
+			throw new UnauthorizedException("Missing or invalid bearer token");
+		}
+
+		return new ValidatedToken(token, tokenType);
+	}
+
+	public record ValidatedToken(
+		String value,
+		TokenType type
+	) {
+	}
+
+	public enum TokenType {
+		API,
+		INGEST
 	}
 }

--- a/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
+++ b/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class BearerAuthenticationFilter extends OncePerRequestFilter {
@@ -55,7 +56,7 @@ public class BearerAuthenticationFilter extends OncePerRequestFilter {
 			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
 				token,
 				token,
-				List.of(new SimpleGrantedAuthority("ROLE_API"))
+				List.of(new SimpleGrantedAuthority(resolveAuthority(token)))
 			);
 			authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 			SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -68,5 +69,13 @@ public class BearerAuthenticationFilter extends OncePerRequestFilter {
 				new BadCredentialsException(exception.getMessage(), exception)
 			);
 		}
+	}
+
+	private String resolveAuthority(String token) {
+		// T-13 범위에서는 endpoint-level 권한 분리를 위해 ingest 토큰 접두사 규칙을 사용한다.
+		if (token.toLowerCase(Locale.ROOT).startsWith("ingest-")) {
+			return "ROLE_INGEST";
+		}
+		return "ROLE_API";
 	}
 }

--- a/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
+++ b/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
@@ -18,7 +18,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class BearerAuthenticationFilter extends OncePerRequestFilter {
@@ -52,11 +51,13 @@ public class BearerAuthenticationFilter extends OncePerRequestFilter {
 		FilterChain filterChain
 	) throws ServletException, IOException {
 		try {
-			String token = bearerTokenValidator.validate(request.getHeader(HttpHeaders.AUTHORIZATION));
+			BearerTokenValidator.ValidatedToken validatedToken = bearerTokenValidator.validate(
+				request.getHeader(HttpHeaders.AUTHORIZATION)
+			);
 			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-				token,
-				token,
-				List.of(new SimpleGrantedAuthority(resolveAuthority(token)))
+				validatedToken.value(),
+				validatedToken.value(),
+				List.of(new SimpleGrantedAuthority(resolveAuthority(validatedToken)))
 			);
 			authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 			SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -71,11 +72,10 @@ public class BearerAuthenticationFilter extends OncePerRequestFilter {
 		}
 	}
 
-	private String resolveAuthority(String token) {
-		// T-13 범위에서는 endpoint-level 권한 분리를 위해 ingest 토큰 접두사 규칙을 사용한다.
-		if (token.toLowerCase(Locale.ROOT).startsWith("ingest-")) {
-			return "ROLE_INGEST";
-		}
-		return "ROLE_API";
+	private String resolveAuthority(BearerTokenValidator.ValidatedToken validatedToken) {
+		return switch (validatedToken.type()) {
+			case INGEST -> "ROLE_INGEST";
+			case API -> "ROLE_API";
+		};
 	}
 }

--- a/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
+++ b/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.logcopilot.common.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.logcopilot.common.api.ApiErrorResponse;
 import com.logcopilot.common.auth.BearerTokenValidator;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,7 +42,8 @@ public class SecurityConfiguration {
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/healthz", "/readyz").permitAll()
 				.requestMatchers("/v1/projects/*/llm-oauth/*/callback").permitAll()
-				.anyRequest().authenticated())
+				.requestMatchers("/v1/ingest/**").hasRole("INGEST")
+				.anyRequest().hasRole("API"))
 			.addFilterBefore(bearerAuthenticationFilter, AnonymousAuthenticationFilter.class);
 
 		return http.build();
@@ -60,7 +62,7 @@ public class SecurityConfiguration {
 		return (request, response, exception) -> writeError(
 			response,
 			HttpStatus.UNAUTHORIZED,
-			ApiErrorResponse.of("unauthorized", "Missing or invalid bearer token"),
+			ApiErrorResponse.of("unauthorized", unauthorizedMessage(request)),
 			objectMapper
 		);
 	}
@@ -88,5 +90,13 @@ public class SecurityConfiguration {
 		response.setStatus(status.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		objectMapper.writeValue(response.getOutputStream(), payload);
+	}
+
+	private String unauthorizedMessage(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		if (path != null && path.startsWith("/v1/ingest/")) {
+			return "Missing or invalid ingest token";
+		}
+		return "Missing or invalid bearer token";
 	}
 }

--- a/src/main/java/com/logcopilot/connector/LokiConnectorController.java
+++ b/src/main/java/com/logcopilot/connector/LokiConnectorController.java
@@ -1,14 +1,12 @@
 package com.logcopilot.connector;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import com.logcopilot.common.error.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,23 +17,16 @@ import java.time.Instant;
 public class LokiConnectorController {
 
 	private final LokiConnectorService lokiConnectorService;
-	private final BearerTokenValidator bearerTokenValidator;
 
-	public LokiConnectorController(
-		LokiConnectorService lokiConnectorService,
-		BearerTokenValidator bearerTokenValidator
-	) {
+	public LokiConnectorController(LokiConnectorService lokiConnectorService) {
 		this.lokiConnectorService = lokiConnectorService;
-		this.bearerTokenValidator = bearerTokenValidator;
 	}
 
 	@PostMapping
 	public ResponseEntity<ConnectorResponse> upsertLokiConnector(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestBody LokiConnectorRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		validateRequestBody(request);
 
 		LokiConnectorService.UpsertResult result = lokiConnectorService.upsert(
@@ -70,11 +61,8 @@ public class LokiConnectorController {
 
 	@PostMapping("/test")
 	public LokiTestResponse testLokiConnector(
-		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization
+		@PathVariable("project_id") String projectId
 	) {
-		bearerTokenValidator.validate(authorization);
-
 		LokiConnectorService.LokiTestResult result = lokiConnectorService.test(projectId);
 		return new LokiTestResponse(
 			new LokiTestData(

--- a/src/main/java/com/logcopilot/incident/IncidentController.java
+++ b/src/main/java/com/logcopilot/incident/IncidentController.java
@@ -1,7 +1,6 @@
 package com.logcopilot.incident;
 
 import com.logcopilot.common.api.ApiMeta;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.common.error.ValidationException;
 import com.logcopilot.incident.domain.IncidentDetail;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,28 +26,23 @@ public class IncidentController {
 
 	private final IncidentService incidentService;
 	private final ProjectService projectService;
-	private final BearerTokenValidator bearerTokenValidator;
 
 	public IncidentController(
 		IncidentService incidentService,
-		ProjectService projectService,
-		BearerTokenValidator bearerTokenValidator
+		ProjectService projectService
 	) {
 		this.incidentService = incidentService;
 		this.projectService = projectService;
-		this.bearerTokenValidator = bearerTokenValidator;
 	}
 
 	@GetMapping("/projects/{project_id}/incidents")
 	public IncidentListResponse listIncidents(
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@PathVariable("project_id") String projectId,
 		@RequestParam(value = "status", required = false) String status,
 		@RequestParam(value = "service", required = false) String service,
 		@RequestParam(value = "cursor", required = false) String cursor,
 		@RequestParam(value = "limit", required = false) Integer limit
 	) {
-		bearerTokenValidator.validate(authorization);
 		validateProjectExists(projectId);
 
 		IncidentListResult result = incidentService.list(projectId, status, service, cursor, limit);
@@ -61,10 +54,8 @@ public class IncidentController {
 
 	@GetMapping("/incidents/{incident_id}")
 	public IncidentDetailResponse getIncident(
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@PathVariable("incident_id") String incidentId
 	) {
-		bearerTokenValidator.validate(authorization);
 		IncidentDetail detail = incidentService.getIncident(incidentId);
 		validateProjectExists(detail.projectId());
 		return new IncidentDetailResponse(detail);
@@ -72,11 +63,9 @@ public class IncidentController {
 
 	@PostMapping("/incidents/{incident_id}/reanalyze")
 	public ResponseEntity<ReanalyzeResponse> reanalyzeIncident(
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@PathVariable("incident_id") String incidentId,
 		@RequestBody(required = false) ReanalyzeRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		String reason = request == null ? null : request.reason();
 		validateReanalyzeReason(reason);
 

--- a/src/main/java/com/logcopilot/ingest/IngestController.java
+++ b/src/main/java/com/logcopilot/ingest/IngestController.java
@@ -1,7 +1,6 @@
 package com.logcopilot.ingest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import com.logcopilot.common.error.BadRequestException;
 import com.logcopilot.common.http.IdempotencyKeyValidator;
 import com.logcopilot.ingest.domain.CanonicalLogEvent;
@@ -23,26 +22,21 @@ import java.util.Map;
 public class IngestController {
 
 	private final IngestService ingestService;
-	private final BearerTokenValidator bearerTokenValidator;
 	private final IdempotencyKeyValidator idempotencyKeyValidator;
 
 	public IngestController(
 		IngestService ingestService,
-		BearerTokenValidator bearerTokenValidator,
 		IdempotencyKeyValidator idempotencyKeyValidator
 	) {
 		this.ingestService = ingestService;
-		this.bearerTokenValidator = bearerTokenValidator;
 		this.idempotencyKeyValidator = idempotencyKeyValidator;
 	}
 
 	@PostMapping("/events")
 	public ResponseEntity<IngestAcceptedResponse> ingestEvents(
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
 		@RequestBody IngestEventsRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		String validatedIdempotencyKey = idempotencyKeyValidator.validateRequired(idempotencyKey);
 		validateRequestBody(request);
 
@@ -55,11 +49,9 @@ public class IngestController {
 
 	@PostMapping(value = "/otlp/logs", consumes = "application/x-protobuf")
 	public ResponseEntity<IngestAcceptedResponse> ingestOtlpLogs(
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
 		@RequestBody(required = false) byte[] payload
 	) {
-		bearerTokenValidator.validate(authorization);
 		String validatedIdempotencyKey = idempotencyKeyValidator.validateRequired(idempotencyKey);
 
 		IngestAcceptedResult accepted = ingestService.ingestOtlpLogs(validatedIdempotencyKey, payload);

--- a/src/main/java/com/logcopilot/llm/LlmAccountController.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountController.java
@@ -1,7 +1,6 @@
 package com.logcopilot.llm;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import com.logcopilot.common.error.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,23 +21,16 @@ import java.util.List;
 public class LlmAccountController {
 
 	private final LlmAccountService llmAccountService;
-	private final BearerTokenValidator bearerTokenValidator;
 
-	public LlmAccountController(
-		LlmAccountService llmAccountService,
-		BearerTokenValidator bearerTokenValidator
-	) {
+	public LlmAccountController(LlmAccountService llmAccountService) {
 		this.llmAccountService = llmAccountService;
-		this.bearerTokenValidator = bearerTokenValidator;
 	}
 
 	@PostMapping("/llm-accounts/api-key")
 	public ResponseEntity<LlmAccountResponse> upsertApiKeyLlmAccount(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestBody LlmApiKeyAccountRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		validateApiKeyRequestBody(request);
 
 		LlmAccountService.UpsertResult result = llmAccountService.upsertApiKey(
@@ -61,11 +52,8 @@ public class LlmAccountController {
 	@PostMapping("/llm-oauth/{provider}/start")
 	public OAuthStartResponse startLlmOAuth(
 		@PathVariable("project_id") String projectId,
-		@PathVariable("provider") String provider,
-		@RequestHeader(value = "Authorization", required = false) String authorization
+		@PathVariable("provider") String provider
 	) {
-		bearerTokenValidator.validate(authorization);
-
 		LlmAccountService.OAuthStartResult result = llmAccountService.startOAuth(projectId, provider);
 		return new OAuthStartResponse(new OAuthStartData(result.authUrl(), result.state()));
 	}
@@ -87,11 +75,7 @@ public class LlmAccountController {
 	}
 
 	@GetMapping("/llm-accounts")
-	public LlmAccountListResponse listLlmAccounts(
-		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization
-	) {
-		bearerTokenValidator.validate(authorization);
+	public LlmAccountListResponse listLlmAccounts(@PathVariable("project_id") String projectId) {
 		List<LlmAccountData> data = llmAccountService.list(projectId).stream()
 			.map(this::toData)
 			.toList();
@@ -101,10 +85,8 @@ public class LlmAccountController {
 	@DeleteMapping("/llm-accounts/{account_id}")
 	public ResponseEntity<Void> deleteLlmAccount(
 		@PathVariable("project_id") String projectId,
-		@PathVariable("account_id") String accountId,
-		@RequestHeader(value = "Authorization", required = false) String authorization
+		@PathVariable("account_id") String accountId
 	) {
-		bearerTokenValidator.validate(authorization);
 		llmAccountService.delete(projectId, accountId);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/logcopilot/policy/PolicyController.java
+++ b/src/main/java/com/logcopilot/policy/PolicyController.java
@@ -1,12 +1,10 @@
 package com.logcopilot.policy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import com.logcopilot.common.error.BadRequestException;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,23 +16,16 @@ import java.util.List;
 public class PolicyController {
 
 	private final PolicyService policyService;
-	private final BearerTokenValidator bearerTokenValidator;
 
-	public PolicyController(
-		PolicyService policyService,
-		BearerTokenValidator bearerTokenValidator
-	) {
+	public PolicyController(PolicyService policyService) {
 		this.policyService = policyService;
-		this.bearerTokenValidator = bearerTokenValidator;
 	}
 
 	@PutMapping("/export")
 	public ExportPolicyResponse updateExportPolicy(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestBody(required = false) ExportPolicyRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		if (request == null) {
 			throw new BadRequestException("Malformed JSON request body");
 		}
@@ -49,10 +40,8 @@ public class PolicyController {
 	@PutMapping("/redaction")
 	public RedactionPolicyResponse updateRedactionPolicy(
 		@PathVariable("project_id") String projectId,
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestBody(required = false) RedactionPolicyRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		if (request == null) {
 			throw new BadRequestException("Malformed JSON request body");
 		}

--- a/src/main/java/com/logcopilot/project/ProjectController.java
+++ b/src/main/java/com/logcopilot/project/ProjectController.java
@@ -1,12 +1,10 @@
 package com.logcopilot.project;
 
-import com.logcopilot.common.auth.BearerTokenValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,32 +15,22 @@ import java.util.List;
 public class ProjectController {
 
 	private final ProjectService projectService;
-	private final BearerTokenValidator bearerTokenValidator;
 
-	public ProjectController(
-		ProjectService projectService,
-		BearerTokenValidator bearerTokenValidator
-	) {
+	public ProjectController(ProjectService projectService) {
 		this.projectService = projectService;
-		this.bearerTokenValidator = bearerTokenValidator;
 	}
 
 	@PostMapping
 	public ResponseEntity<ProjectResponse> createProject(
-		@RequestHeader(value = "Authorization", required = false) String authorization,
 		@RequestBody CreateProjectRequest request
 	) {
-		bearerTokenValidator.validate(authorization);
 		ProjectDto project = projectService.create(request.name(), request.environment());
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(new ProjectResponse(project));
 	}
 
 	@GetMapping
-	public ProjectListResponse listProjects(
-		@RequestHeader(value = "Authorization", required = false) String authorization
-	) {
-		bearerTokenValidator.validate(authorization);
+	public ProjectListResponse listProjects() {
 		return new ProjectListResponse(projectService.list());
 	}
 

--- a/src/main/java/com/logcopilot/system/SystemController.java
+++ b/src/main/java/com/logcopilot/system/SystemController.java
@@ -1,21 +1,13 @@
 package com.logcopilot.system;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.logcopilot.common.auth.BearerTokenValidator;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 @RestController
 public class SystemController {
-
-	private final BearerTokenValidator bearerTokenValidator;
-
-	public SystemController(BearerTokenValidator bearerTokenValidator) {
-		this.bearerTokenValidator = bearerTokenValidator;
-	}
 
 	@GetMapping("/healthz")
 	public HealthResponse healthz() {
@@ -28,10 +20,7 @@ public class SystemController {
 	}
 
 	@GetMapping("/v1/system/info")
-	public SystemInfoResponse getSystemInfo(
-		@RequestHeader(value = "Authorization", required = false) String authorization
-	) {
-		bearerTokenValidator.validate(authorization);
+	public SystemInfoResponse getSystemInfo() {
 		return new SystemInfoResponse(
 			new SystemInfoData(
 				"1.0.0-mvp",

--- a/src/test/java/com/logcopilot/common/auth/BearerTokenValidatorTest.java
+++ b/src/test/java/com/logcopilot/common/auth/BearerTokenValidatorTest.java
@@ -12,11 +12,21 @@ class BearerTokenValidatorTest {
 	private final BearerTokenValidator validator = new BearerTokenValidator();
 
 	@Test
-	@DisplayName("BearerTokenValidator는 유효한 bearer 토큰을 반환한다")
-	void returnsTokenWhenAuthorizationHeaderIsValid() {
-		String token = validator.validate("Bearer test-token");
+	@DisplayName("BearerTokenValidator는 검증된 API 토큰을 반환한다")
+	void returnsValidatedApiTokenWhenAuthorizationHeaderIsValid() {
+		BearerTokenValidator.ValidatedToken token = validator.validate("Bearer test-token");
 
-		assertThat(token).isEqualTo("test-token");
+		assertThat(token.value()).isEqualTo("test-token");
+		assertThat(token.type()).isEqualTo(BearerTokenValidator.TokenType.API);
+	}
+
+	@Test
+	@DisplayName("BearerTokenValidator는 검증된 ingest 토큰을 반환한다")
+	void returnsValidatedIngestTokenWhenAuthorizationHeaderIsValid() {
+		BearerTokenValidator.ValidatedToken token = validator.validate("Bearer ingest-token");
+
+		assertThat(token.value()).isEqualTo("ingest-token");
+		assertThat(token.type()).isEqualTo(BearerTokenValidator.TokenType.INGEST);
 	}
 
 	@Test
@@ -47,6 +57,14 @@ class BearerTokenValidatorTest {
 	@DisplayName("BearerTokenValidator는 토큰 뒤에 추가 세그먼트가 있으면 예외를 던진다")
 	void throwsWhenAuthorizationHasMultipleSegments() {
 		assertThatThrownBy(() -> validator.validate("Bearer token extra"))
+			.isInstanceOf(UnauthorizedException.class)
+			.hasMessage("Missing or invalid bearer token");
+	}
+
+	@Test
+	@DisplayName("BearerTokenValidator는 등록되지 않은 토큰이면 예외를 던진다")
+	void throwsWhenTokenIsNotRegistered() {
+		assertThatThrownBy(() -> validator.validate("Bearer unknown-token"))
 			.isInstanceOf(UnauthorizedException.class)
 			.hasMessage("Missing or invalid bearer token");
 	}

--- a/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
+++ b/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
@@ -52,4 +52,42 @@ class SecurityEndpointsIntegrationTest {
 			.andExpect(jsonPath("$.error.code").value("unauthorized"))
 			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
 	}
+
+	@Test
+	@DisplayName("ingest 토큰으로 일반 API 접근 시 403을 반환한다")
+	void apiEndpointsReturn403ForIngestToken() throws Exception {
+		mockMvc.perform(get("/v1/system/info")
+				.header("Authorization", "Bearer ingest-token"))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error.code").value("forbidden"))
+			.andExpect(jsonPath("$.error.message").value("Access denied"));
+	}
+
+	@Test
+	@DisplayName("일반 bearer 토큰으로 ingest API 접근 시 403을 반환한다")
+	void ingestEndpointsReturn403ForBearerToken() throws Exception {
+		mockMvc.perform(post("/v1/ingest/events")
+				.header("Authorization", "Bearer api-token")
+				.header("Idempotency-Key", "idem-security-1")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "project_id": "project-1",
+					  "source": "loki",
+					  "batch_id": "batch-1",
+					  "events": [
+					    {
+					      "event_id": "evt-1",
+					      "timestamp": "2026-03-03T03:00:00Z",
+					      "service": "api",
+					      "severity": "error",
+					      "message": "failure"
+					    }
+					  ]
+					}
+					"""))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error.code").value("forbidden"))
+			.andExpect(jsonPath("$.error.message").value("Access denied"));
+	}
 }

--- a/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
+++ b/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
@@ -90,4 +90,14 @@ class SecurityEndpointsIntegrationTest {
 			.andExpect(jsonPath("$.error.code").value("forbidden"))
 			.andExpect(jsonPath("$.error.message").value("Access denied"));
 	}
+
+	@Test
+	@DisplayName("등록되지 않은 bearer 토큰은 401로 차단한다")
+	void unknownBearerTokenReturns401() throws Exception {
+		mockMvc.perform(get("/v1/system/info")
+				.header("Authorization", "Bearer unknown-token"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.error.code").value("unauthorized"))
+			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
+	}
 }

--- a/src/test/java/com/logcopilot/incident/IncidentControllerTest.java
+++ b/src/test/java/com/logcopilot/incident/IncidentControllerTest.java
@@ -47,7 +47,8 @@ class IncidentControllerTest {
 
 	@BeforeEach
 	void setUpAuthenticationStub() {
-		when(bearerTokenValidator.validate("Bearer token")).thenReturn("token");
+		when(bearerTokenValidator.validate("Bearer token"))
+			.thenReturn(new BearerTokenValidator.ValidatedToken("token", BearerTokenValidator.TokenType.API));
 	}
 
 	@Test

--- a/src/test/java/com/logcopilot/ingest/IngestEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/ingest/IngestEndpointsContractTest.java
@@ -97,8 +97,8 @@ class IngestEndpointsContractTest {
 	}
 
 	@Test
-	@DisplayName("POST /v1/ingest/events 는 인증 누락 시 401을 반환한다")
-	void ingestEventsRejectsMissingBearerToken() throws Exception {
+	@DisplayName("POST /v1/ingest/events 는 ingest 토큰 누락 시 401을 반환한다")
+	void ingestEventsRejectsMissingIngestToken() throws Exception {
 		String projectId = createProjectId("ingest-auth");
 
 		mockMvc.perform(post("/v1/ingest/events")
@@ -112,7 +112,7 @@ class IngestEndpointsContractTest {
 				)))
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.error.code").value("unauthorized"))
-			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
+			.andExpect(jsonPath("$.error.message").value("Missing or invalid ingest token"));
 	}
 
 	@Test


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - 컨트롤러의 수동 `BearerTokenValidator` 호출을 제거하고 인증/인가 경계를 Spring Security 체인으로 일원화했습니다.
  - `/v1/ingest/**` 와 일반 API의 권한을 분리(`ROLE_INGEST`/`ROLE_API`)했습니다.
  - ingest 경로 무인증 메시지를 `Missing or invalid ingest token`으로 분리하고 403 경계 테스트를 추가했습니다.
- 왜 필요한가:
  - OpenAPI의 `bearerAuth`/`ingestToken` 스킴을 구현 경계에 반영해 401/403 정책 일관성을 확보하기 위해서입니다.

## 연결 이슈
- Closes #32

## 범위 점검
- 포함:
  - 보안 체인 경로별 권한 규칙 추가
  - 인증 실패 메시지 분기(ingest vs bearer)
  - 컨트롤러 인증 중복 제거
  - 보안/계약 테스트 보강
- 제외:
  - OAuth state TTL/재사용 방지(T-15)
  - Validation 표준화(T-14)
  - 영속화/암호화 저장소 전환(T-21)

## 주요 변경 사항
- `SecurityConfiguration`에서 `/v1/ingest/**`에 `ROLE_INGEST` 강제, 나머지 보호 API에 `ROLE_API` 강제
- `BearerAuthenticationFilter`에서 토큰 접두사(`ingest-`) 기반 권한 분기
- `Project/System/Connector/Ingest/Incident/Llm/Alert/Policy` 컨트롤러의 수동 bearer 검증 제거
- `AlertController` actor 토큰 획득을 `Authentication` 기반으로 전환
- `SecurityEndpointsIntegrationTest`에 403 경계 2건 추가
- `IngestEndpointsContractTest`의 401 메시지 기대값을 ingest 전용으로 정렬
- 세션 노트 추가: `docs/sessions/2026-03-04-T-13.md`

## TDD 근거
- RED:
  - `./gradlew test --tests "*SecurityEndpointsIntegrationTest" --tests "*IngestEndpointsContractTest"` 실행 시 3건 실패
- GREEN:
  - 동일 명령 PASS
  - `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` PASS
- REFACTOR:
  - 컨트롤러 인증 헤더 시그니처 정리 및 보안 경계 단일화

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC2 -> `./gradlew test --tests "*Security*Test" --tests "*EndpointsContractTest"` -> PASS
- AC2 -> `./gradlew check` -> PASS
- AC2 -> `./gradlew test` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 대기 중
- codex:
  - 대기 중

## 리스크 / 롤백
- 확인된 리스크:
  - 토큰 타입 판별이 접두사 규칙(`ingest-`) 기반이라 운영 키 규칙 변경 시 재정의가 필요합니다.
- 롤백 계획:
  - `SecurityConfiguration` 권한 분리 규칙과 `BearerAuthenticationFilter` 권한 분기 로직을 이전 정책으로 되돌립니다.

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-14: DTO `@Valid` 적용 및 ValidationError 응답 정규화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선 사항**
  * 인증 오류 메시지 명확화: 수집 토큰과 API 토큰 요청 시 구분된 오류 메시지 제공
  * 역할 기반 접근 제어 강화로 API 엔드포인트와 수집 엔드포인트 간 보안 분리 개선

* **테스트**
  * 토큰 유형별 접근 제어 검증 테스트 추가
  * 통합 보안 테스트 확대로 인증 흐름 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->