### PR TITLE
[T-15] OAuth2(OpenAI/Gemini) 실연동 안정화

### DIFF
--- a/docs/api/openapi-selfhosted-byom-v1.yaml
+++ b/docs/api/openapi-selfhosted-byom-v1.yaml
@@ -235,12 +235,25 @@ paths:
         - $ref: '#/components/parameters/OAuthProvider'
         - name: code
           in: query
-          required: true
+          required: false
+          description: Authorization code (required when `error` is absent)
           schema:
             type: string
         - name: state
           in: query
           required: true
+          schema:
+            type: string
+        - name: error
+          in: query
+          required: false
+          description: Provider callback error code
+          schema:
+            type: string
+        - name: error_description
+          in: query
+          required: false
+          description: Provider callback error detail
           schema:
             type: string
       responses:

--- a/docs/api/openapi-selfhosted-byom-v1.yaml
+++ b/docs/api/openapi-selfhosted-byom-v1.yaml
@@ -236,7 +236,7 @@ paths:
         - name: code
           in: query
           required: false
-          description: Authorization code (required when `error` is absent)
+          description: Authorization code (required when `error` is absent; ignored when `error` is present)
           schema:
             type: string
         - name: state
@@ -247,7 +247,7 @@ paths:
         - name: error
           in: query
           required: false
-          description: Provider callback error code
+          description: Provider callback error code (takes precedence over `code`)
           schema:
             type: string
         - name: error_description

--- a/docs/domain/oauth2-provider-modes.md
+++ b/docs/domain/oauth2-provider-modes.md
@@ -6,6 +6,7 @@
 ## Configuration Keys
 - `logcopilot.llm.oauth.mode`: `stub` | `live`
 - `logcopilot.llm.oauth.state-ttl`: OAuth state TTL (`PT10M` 기본)
+- `logcopilot.llm.oauth.max-state-entries`: OAuth state in-memory 상한
 - `logcopilot.llm.oauth.callback-base-url`: callback 절대 URL 기준값
 - `logcopilot.llm.oauth.<provider>.client-id`
 - `logcopilot.llm.oauth.<provider>.authorization-uri` (live)
@@ -20,12 +21,14 @@
   - 목적: 외부 OAuth provider 의존성 없이 start/callback/state 정책 검증
 2. 스테이징/운영 환경:
   - `mode=live`
+  - `callback-base-url`은 `https` + non-local host만 허용된다.
   - 목적: 실제 provider authorization endpoint를 사용해 redirect 흐름을 검증
   - 주의: MVP T-15에서는 provider token exchange/issuer 검증은 범위 밖이며, callback `code` 존재 여부와 state 정책만 검증한다.
 
 ## Callback Policy
 - `state`는 항상 필수이며 TTL 만료 또는 재사용 시 `409 conflict`를 반환한다.
 - provider가 `error`를 반환하면 `400 bad_request`로 매핑한다.
+- `error`와 `code`가 동시에 오면 `error`를 우선 처리하고 `code`는 무시한다.
 - `error`가 없으면 `code`가 필수이며 누락/공백은 `400 bad_request`다.
 
 ## Operational Notes

--- a/docs/domain/oauth2-provider-modes.md
+++ b/docs/domain/oauth2-provider-modes.md
@@ -1,0 +1,33 @@
+# OAuth2 Provider Mode Guide (OpenAI/Gemini)
+
+## Purpose
+`T-15` 기준으로 로컬 개발(stub)과 실제 provider(live) 전환 기준을 고정한다.
+
+## Configuration Keys
+- `logcopilot.llm.oauth.mode`: `stub` | `live`
+- `logcopilot.llm.oauth.state-ttl`: OAuth state TTL (`PT10M` 기본)
+- `logcopilot.llm.oauth.callback-base-url`: callback 절대 URL 기준값
+- `logcopilot.llm.oauth.<provider>.client-id`
+- `logcopilot.llm.oauth.<provider>.authorization-uri` (live)
+- `logcopilot.llm.oauth.<provider>.stub-authorization-uri` (stub)
+- `logcopilot.llm.oauth.<provider>.scopes`
+
+`<provider>`는 `openai`, `gemini`만 허용한다.
+
+## Mode Selection Rule
+1. 로컬/테스트 환경:
+  - `mode=stub`
+  - 목적: 외부 OAuth provider 의존성 없이 start/callback/state 정책 검증
+2. 스테이징/운영 환경:
+  - `mode=live`
+  - 목적: 실제 provider authorization endpoint를 사용해 redirect 흐름을 검증
+  - 주의: MVP T-15에서는 provider token exchange/issuer 검증은 범위 밖이며, callback `code` 존재 여부와 state 정책만 검증한다.
+
+## Callback Policy
+- `state`는 항상 필수이며 TTL 만료 또는 재사용 시 `409 conflict`를 반환한다.
+- provider가 `error`를 반환하면 `400 bad_request`로 매핑한다.
+- `error`가 없으면 `code`가 필수이며 누락/공백은 `400 bad_request`다.
+
+## Operational Notes
+- `callback-base-url`은 외부 provider에 등록된 redirect URI와 반드시 일치해야 한다.
+- mode 전환 시 `authorization-uri`와 `client-id`를 환경변수/시크릿으로 주입한다.

--- a/docs/sessions/2026-03-04-T-15.md
+++ b/docs/sessions/2026-03-04-T-15.md
@@ -1,0 +1,102 @@
+# Session Task Note - T-15
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #36
+- Branch: `feature/36-t15-oauth2-hardening`
+- Task ID: T-15
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - OpenAI/Gemini OAuth start URL을 프로퍼티 기반으로 정리한다.
+  - OAuth state TTL/재사용 방지 정책을 단일 경로로 강화한다.
+  - callback provider 오류(`error`, `error_description`) 매핑을 고정한다.
+  - local stub/live 모드 전환 기준을 문서화한다.
+- Do not do now:
+  - 실제 provider token exchange/refresh 구현.
+  - SQLite 영속화/시크릿 암호화 저장소 전환(T-21).
+  - Loki pull/cursor commit(T-16).
+- Done means:
+  - start/callback/state 시나리오가 테스트로 고정되고 통과한다.
+  - OpenAPI callback 파라미터 계약이 코드와 일치한다.
+  - stub/live 전환 가이드가 문서화된다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction` -> `openapi` -> `architecture-guardrails` -> workflow -> active spec 순으로 점검.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - OpenAI/Gemini 계정 수명주기 안정화는 MVP in-scope 작업이다.
+- AC-to-rule mapping to execute:
+  - AC3(T-15) -> Unit/Integration -> `./gradlew test --tests "*LlmAccount*Test" --tests "*OAuth*Test"` -> PASS
+  - Gate -> `./gradlew check` -> PASS
+  - Gate -> `./gradlew test` -> PASS
+  - Gate -> `./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. RED: OAuth 설정/상태/오류 매핑 케이스를 테스트 먼저 추가해 실패를 고정한다.
+2. GREEN: 프로퍼티 클래스 + 서비스/컨트롤러 + OpenAPI/문서를 최소 변경으로 반영한다.
+3. REFACTOR: 설정 fail-fast, state 저장소 상한, 문서 범위 명확화를 보강한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java`
+  - `src/test/java/com/logcopilot/llm/LlmAccountEndpointsContractTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*LlmAccount*Test"` 실행 시 `compileTestJava` 실패(신규 `LlmOAuthProperties` 미존재, callback 시그니처 불일치).
+- GREEN pass output summary:
+  - `./gradlew test --tests "*LlmAccount*Test"` PASS
+  - `./gradlew test --tests "*LlmAccount*Test" --tests "*OAuth*Test"` PASS
+- REFACTOR summary:
+  - `LlmOAuthProperties`에 `stateTtl`, `callbackBaseUrl`, `maxStateEntries` fail-fast 검증을 추가.
+  - OAuth state 저장소 상한 초과 시 가장 오래된 state를 제거하도록 정책 보강.
+  - provider 오류 메시지에 `error_description`(길이 제한)을 포함하고 문서 범위를 명확화.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/llm/LlmOAuthProperties.java`
+  - `src/main/java/com/logcopilot/llm/LlmAccountService.java`
+  - `src/main/java/com/logcopilot/llm/LlmAccountController.java`
+  - `src/main/resources/application.properties`
+  - `src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java`
+  - `src/test/java/com/logcopilot/llm/LlmAccountEndpointsContractTest.java`
+  - `src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java`
+  - `docs/api/openapi-selfhosted-byom-v1.yaml`
+  - `docs/domain/oauth2-provider-modes.md`
+- Why this approach:
+  - 기존 계약(200/400/409)을 유지하면서 state 정책과 provider 오류 매핑을 고도화하는 최소 변경 경로다.
+  - stub/live를 프로퍼티로 분리해 운영 전환 리스크를 낮추고 테스트 재현성을 높였다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*LlmAccount*Test"` (RED 실패 확인, GREEN 재검증)
+  - `./gradlew test --tests "*LlmAccount*Test" --tests "*OAuth*Test"`
+  - `./gradlew check`
+  - `./gradlew test`
+  - `./gradlew build`
+- Results:
+  - RED 컴파일 실패 확인 후 GREEN/REFACTOR 단계에서 모든 명령 PASS.
+  - `check/test/build` 순차 실행으로 최종 게이트 green 확인.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Explorer sub-agent `Aristotle`
+- Findings:
+  - live 모드 설명이 실제 구현 범위를 초과해 오해 소지가 있음.
+  - OAuth 설정값 fail-fast 검증 부족.
+  - OAuth state 저장소 상한 부재.
+  - provider 오류 상세 미노출.
+- Resolution:
+  - 문서에 MVP 범위(authorization redirect + state 정책, token exchange는 out-of-scope)를 명시.
+  - `LlmOAuthProperties`에 TTL/callback URL 검증 추가.
+  - `maxStateEntries` 상한 및 오래된 state eviction 정책 추가.
+  - provider 오류 응답 메시지에 `error_description` 일부를 포함.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - live 모드에서도 provider token exchange/issuer 검증은 아직 미구현(후속 태스크에서 보완 필요).
+- Next task ID:
+  - T-16
+- Suggested first check for next session:
+  - Loki pull 결과를 push ingest canonical pipeline과 동일 경로로 합류시키는 RED 테스트를 먼저 고정.

--- a/docs/sessions/2026-03-04-T-15.md
+++ b/docs/sessions/2026-03-04-T-15.md
@@ -100,3 +100,21 @@ Use `docs/templates/commit-message.template.md`.
   - T-16
 - Suggested first check for next session:
   - Loki pull 결과를 push ingest canonical pipeline과 동일 경로로 합류시키는 RED 테스트를 먼저 고정.
+
+## 9. PR Review Follow-up (PR #37)
+- Reason:
+  - CodeRabbit 인라인 리뷰에서 state 누수(P1), LIVE callback 안전성, 설정/문서 정합성 보강 요청이 제기됨.
+- Changes:
+  - `startOAuth`에서 auth URL 생성 성공 후에만 state 저장/eviction이 일어나도록 순서 수정.
+  - `LlmOAuthProperties`에 `setMaxStateEntries` 양수 검증 추가.
+  - LIVE 모드에서 `https + non-local host` callback URL을 강제하도록 검증 추가.
+  - OpenAPI callback 파라미터 설명에 `error` 우선 규칙을 명시.
+  - `application.properties`에 `logcopilot.llm.oauth.max-state-entries`를 명시.
+  - 테스트 보강:
+    - `LlmOAuthPropertiesTest`: LIVE 모드 제약, maxStateEntries 제약
+    - `LlmAccountServiceTest`: start 실패 시 state 미저장 보장, eviction 테스트 전용 서비스 인스턴스 사용
+- Re-run verification:
+  - `./gradlew test --tests "*LlmAccount*Test" --tests "*LlmOAuthPropertiesTest" --tests "*OAuth*Test"` => PASS
+  - `./gradlew check` => PASS
+  - `./gradlew test` => PASS
+  - `./gradlew build` => PASS

--- a/src/main/java/com/logcopilot/llm/LlmAccountController.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountController.java
@@ -64,13 +64,17 @@ public class LlmAccountController {
 		@PathVariable("project_id") String projectId,
 		@PathVariable("provider") String provider,
 		@RequestParam(value = "code", required = false) String code,
-		@RequestParam(value = "state", required = false) String state
+		@RequestParam(value = "state", required = false) String state,
+		@RequestParam(value = "error", required = false) String error,
+		@RequestParam(value = "error_description", required = false) String errorDescription
 	) {
 		LlmAccountService.OAuthCallbackResult result = llmAccountService.callbackOAuth(
 			projectId,
 			provider,
 			code,
-			state
+			state,
+			error,
+			errorDescription
 		);
 		return new OAuthCallbackResponse(new OAuthCallbackData(result.linked(), result.accountId()));
 	}

--- a/src/main/java/com/logcopilot/llm/LlmAccountService.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountService.java
@@ -74,7 +74,7 @@ public class LlmAccountService {
 				label,
 				model,
 				"active",
-				Instant.now(),
+				Instant.now(clock),
 				baseUrl,
 				command.apiKey()
 			);
@@ -107,11 +107,11 @@ public class LlmAccountService {
 		requireProjectForScopedRequest(projectId);
 		String provider = validateProviderForBadRequest(providerInput);
 		purgeExpiredOAuthStates();
-		enforceOAuthStateCapacity();
 
 		String state = UUID.randomUUID().toString();
-		oauthStateByValue.put(state, new OAuthState(projectId, provider, Instant.now(clock)));
 		String authUrl = buildAuthorizationUrl(projectId, provider, state);
+		enforceOAuthStateCapacity();
+		oauthStateByValue.put(state, new OAuthState(projectId, provider, Instant.now(clock)));
 		return new OAuthStartResult(authUrl, state);
 	}
 
@@ -375,19 +375,17 @@ public class LlmAccountService {
 
 	private void enforceOAuthStateCapacity() {
 		int maxEntries = oauthProperties.getMaxStateEntries();
-		if (maxEntries <= 0) {
+		int overflowCount = oauthStateByValue.size() - maxEntries + 1;
+		if (overflowCount <= 0) {
 			return;
 		}
-		while (oauthStateByValue.size() >= maxEntries) {
-			String oldestState = oauthStateByValue.entrySet().stream()
-				.min(Comparator.comparing(entry -> entry.getValue().createdAt()))
-				.map(Map.Entry::getKey)
-				.orElse(null);
-			if (oldestState == null) {
-				return;
-			}
-			oauthStateByValue.remove(oldestState);
-		}
+
+		List<String> oldestStates = oauthStateByValue.entrySet().stream()
+			.sorted(Comparator.comparing(entry -> entry.getValue().createdAt()))
+			.limit(overflowCount)
+			.map(Map.Entry::getKey)
+			.toList();
+		oldestStates.forEach(oauthStateByValue::remove);
 	}
 
 	private LlmAccount toLlmAccount(AccountState state) {

--- a/src/main/java/com/logcopilot/llm/LlmAccountService.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountService.java
@@ -333,7 +333,17 @@ public class LlmAccountService {
 	private String buildAuthorizationUrl(String projectId, String provider, String state) {
 		LlmOAuthProperties.ProviderSettings settings = oauthProperties.provider(provider);
 		String authorizationUri = oauthProperties.authorizationUriFor(provider);
-		if (settings == null || authorizationUri == null || authorizationUri.isBlank()) {
+		if (settings == null
+			|| authorizationUri == null || authorizationUri.isBlank()
+			|| settings.getClientId() == null || settings.getClientId().isBlank()
+			|| settings.getScopes() == null || settings.getScopes().isEmpty()) {
+			throw new BadRequestException("OAuth provider is not configured");
+		}
+		List<String> scopes = settings.getScopes().stream()
+			.map(String::trim)
+			.filter(scope -> !scope.isEmpty())
+			.toList();
+		if (scopes.isEmpty()) {
 			throw new BadRequestException("OAuth provider is not configured");
 		}
 		String redirectUri = UriComponentsBuilder
@@ -345,7 +355,7 @@ public class LlmAccountService {
 			.fromUriString(authorizationUri)
 			.queryParam("response_type", "code")
 			.queryParam("client_id", settings.getClientId())
-			.queryParam("scope", String.join(" ", settings.getScopes()))
+			.queryParam("scope", String.join(" ", scopes))
 			.queryParam("redirect_uri", redirectUri)
 			.queryParam("state", state)
 			.build()

--- a/src/main/java/com/logcopilot/llm/LlmAccountService.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountService.java
@@ -5,12 +5,15 @@ import com.logcopilot.common.error.ConflictException;
 import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.common.error.ValidationException;
 import com.logcopilot.project.ProjectService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Duration;
+import java.time.Clock;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -21,15 +24,23 @@ import java.util.UUID;
 @Service
 public class LlmAccountService {
 
-	private static final Duration OAUTH_STATE_TTL = Duration.ofMinutes(10);
 	private final ProjectService projectService;
+	private final LlmOAuthProperties oauthProperties;
+	private final Clock clock;
 	private final Map<String, LinkedHashMap<String, AccountState>> accountsByProject = new HashMap<>();
 	private final Map<String, Map<String, String>> apiKeyAccountIdByProjectProvider = new HashMap<>();
 	private final Map<String, Map<String, String>> oauthAccountIdByProjectProvider = new HashMap<>();
 	private final Map<String, OAuthState> oauthStateByValue = new HashMap<>();
 
-	public LlmAccountService(ProjectService projectService) {
+	@Autowired
+	public LlmAccountService(ProjectService projectService, LlmOAuthProperties oauthProperties) {
+		this(projectService, oauthProperties, Clock.systemUTC());
+	}
+
+	LlmAccountService(ProjectService projectService, LlmOAuthProperties oauthProperties, Clock clock) {
 		this.projectService = projectService;
+		this.oauthProperties = oauthProperties;
+		this.clock = clock;
 	}
 
 	public synchronized UpsertResult upsertApiKey(String projectId, ApiKeyUpsertCommand command) {
@@ -96,11 +107,11 @@ public class LlmAccountService {
 		requireProjectForScopedRequest(projectId);
 		String provider = validateProviderForBadRequest(providerInput);
 		purgeExpiredOAuthStates();
+		enforceOAuthStateCapacity();
 
 		String state = UUID.randomUUID().toString();
-		oauthStateByValue.put(state, new OAuthState(projectId, provider, Instant.now()));
-		String authUrl = "https://auth.%s.example.com/oauth/authorize?project_id=%s&state=%s"
-			.formatted(provider, projectId, state);
+		oauthStateByValue.put(state, new OAuthState(projectId, provider, Instant.now(clock)));
+		String authUrl = buildAuthorizationUrl(projectId, provider, state);
 		return new OAuthStartResult(authUrl, state);
 	}
 
@@ -108,14 +119,15 @@ public class LlmAccountService {
 		String projectId,
 		String providerInput,
 		String code,
-		String state
+		String state,
+		String providerError,
+		String providerErrorDescription
 	) {
 		requireProjectForScopedRequest(projectId);
 		String provider = validateProviderForBadRequest(providerInput);
-		validateCode(code);
 		validateState(state);
 		purgeExpiredOAuthStates();
-		Instant now = Instant.now();
+		Instant now = Instant.now(clock);
 
 		OAuthState started = oauthStateByValue.get(state);
 		if (started == null) {
@@ -126,9 +138,14 @@ public class LlmAccountService {
 			throw new ConflictException("Invalid or expired oauth state");
 		}
 		if (!started.projectId().equals(projectId) || !started.provider().equals(provider)) {
+			oauthStateByValue.remove(state);
 			throw new ConflictException("Invalid or expired oauth state");
 		}
 		oauthStateByValue.remove(state);
+		if (hasProviderError(providerError)) {
+			throw new BadRequestException(providerErrorMessage(providerError, providerErrorDescription));
+		}
+		validateCode(code);
 
 		LinkedHashMap<String, AccountState> accounts = accountsByProject.computeIfAbsent(
 			projectId,
@@ -152,7 +169,7 @@ public class LlmAccountService {
 			provider + "-oauth",
 			defaultModel(provider),
 			"active",
-			Instant.now(),
+			Instant.now(clock),
 			null,
 			null
 		);
@@ -289,12 +306,12 @@ public class LlmAccountService {
 	}
 
 	private void purgeExpiredOAuthStates() {
-		Instant now = Instant.now();
+		Instant now = Instant.now(clock);
 		oauthStateByValue.entrySet().removeIf(entry -> isExpired(entry.getValue(), now));
 	}
 
 	private boolean isExpired(OAuthState state, Instant now) {
-		return state.createdAt().isBefore(now.minus(OAUTH_STATE_TTL));
+		return !state.createdAt().plus(oauthProperties.getStateTtl()).isAfter(now);
 	}
 
 	private void validateCode(String code) {
@@ -311,6 +328,66 @@ public class LlmAccountService {
 
 	private String defaultModel(String provider) {
 		return "openai".equals(provider) ? "gpt-4o-mini" : "gemini-2.0-flash";
+	}
+
+	private String buildAuthorizationUrl(String projectId, String provider, String state) {
+		LlmOAuthProperties.ProviderSettings settings = oauthProperties.provider(provider);
+		String authorizationUri = oauthProperties.authorizationUriFor(provider);
+		if (settings == null || authorizationUri == null || authorizationUri.isBlank()) {
+			throw new BadRequestException("OAuth provider is not configured");
+		}
+		String redirectUri = UriComponentsBuilder
+			.fromUriString(oauthProperties.getCallbackBaseUrl())
+			.path("/v1/projects/{project_id}/llm-oauth/{provider}/callback")
+			.buildAndExpand(projectId, provider)
+			.toUriString();
+		return UriComponentsBuilder
+			.fromUriString(authorizationUri)
+			.queryParam("response_type", "code")
+			.queryParam("client_id", settings.getClientId())
+			.queryParam("scope", String.join(" ", settings.getScopes()))
+			.queryParam("redirect_uri", redirectUri)
+			.queryParam("state", state)
+			.build()
+			.encode()
+			.toUriString();
+	}
+
+	private boolean hasProviderError(String providerError) {
+		return providerError != null && !providerError.trim().isEmpty();
+	}
+
+	private String providerErrorMessage(String providerError, String providerErrorDescription) {
+		String normalizedError = providerError.trim().toLowerCase(Locale.ROOT);
+		String baseMessage = "OAuth provider returned error: " + normalizedError;
+		if (providerErrorDescription == null || providerErrorDescription.trim().isEmpty()) {
+			return baseMessage;
+		}
+		return baseMessage + " (" + truncate(providerErrorDescription.trim(), 80) + ")";
+	}
+
+	private String truncate(String value, int maxLength) {
+		if (value.length() <= maxLength) {
+			return value;
+		}
+		return value.substring(0, maxLength);
+	}
+
+	private void enforceOAuthStateCapacity() {
+		int maxEntries = oauthProperties.getMaxStateEntries();
+		if (maxEntries <= 0) {
+			return;
+		}
+		while (oauthStateByValue.size() >= maxEntries) {
+			String oldestState = oauthStateByValue.entrySet().stream()
+				.min(Comparator.comparing(entry -> entry.getValue().createdAt()))
+				.map(Map.Entry::getKey)
+				.orElse(null);
+			if (oldestState == null) {
+				return;
+			}
+			oauthStateByValue.remove(oldestState);
+		}
 	}
 
 	private LlmAccount toLlmAccount(AccountState state) {

--- a/src/main/java/com/logcopilot/llm/LlmOAuthProperties.java
+++ b/src/main/java/com/logcopilot/llm/LlmOAuthProperties.java
@@ -1,0 +1,210 @@
+package com.logcopilot.llm;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Component
+@ConfigurationProperties(prefix = "logcopilot.llm.oauth")
+@Validated
+public class LlmOAuthProperties {
+
+	private static final Duration DEFAULT_STATE_TTL = Duration.ofMinutes(10);
+
+	@NotNull
+	private Mode mode = Mode.STUB;
+
+	@NotNull
+	private Duration stateTtl = DEFAULT_STATE_TTL;
+
+	@NotBlank
+	private String callbackBaseUrl = "http://localhost:8080";
+
+	@Positive
+	private int maxStateEntries = 10000;
+
+	@Valid
+	@NotNull
+	private ProviderSettings openai = ProviderSettings.defaultOpenai();
+
+	@Valid
+	@NotNull
+	private ProviderSettings gemini = ProviderSettings.defaultGemini();
+
+	public static LlmOAuthProperties defaultProperties() {
+		return new LlmOAuthProperties();
+	}
+
+	public ProviderSettings provider(String provider) {
+		String normalized = provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
+		return switch (normalized) {
+			case "openai" -> openai;
+			case "gemini" -> gemini;
+			default -> null;
+		};
+	}
+
+	public String authorizationUriFor(String provider) {
+		ProviderSettings settings = provider(provider);
+		if (settings == null) {
+			return null;
+		}
+		return mode == Mode.LIVE ? settings.getAuthorizationUri() : settings.getStubAuthorizationUri();
+	}
+
+	public Mode getMode() {
+		return mode;
+	}
+
+	public void setMode(Mode mode) {
+		this.mode = mode;
+	}
+
+	public Duration getStateTtl() {
+		return stateTtl;
+	}
+
+	public void setStateTtl(Duration stateTtl) {
+		if (stateTtl == null) {
+			this.stateTtl = DEFAULT_STATE_TTL;
+			return;
+		}
+		if (stateTtl.isZero() || stateTtl.isNegative()) {
+			throw new IllegalArgumentException("stateTtl must be positive");
+		}
+		this.stateTtl = stateTtl;
+	}
+
+	public String getCallbackBaseUrl() {
+		return callbackBaseUrl;
+	}
+
+	public void setCallbackBaseUrl(String callbackBaseUrl) {
+		validateCallbackBaseUrl(callbackBaseUrl);
+		this.callbackBaseUrl = callbackBaseUrl;
+	}
+
+	public int getMaxStateEntries() {
+		return maxStateEntries;
+	}
+
+	public void setMaxStateEntries(int maxStateEntries) {
+		this.maxStateEntries = maxStateEntries;
+	}
+
+	public ProviderSettings getOpenai() {
+		return openai;
+	}
+
+	public void setOpenai(ProviderSettings openai) {
+		this.openai = openai;
+	}
+
+	public ProviderSettings getGemini() {
+		return gemini;
+	}
+
+	public void setGemini(ProviderSettings gemini) {
+		this.gemini = gemini;
+	}
+
+	public enum Mode {
+		STUB,
+		LIVE
+	}
+
+	public static class ProviderSettings {
+
+		@NotBlank
+		private String clientId;
+
+		@NotBlank
+		private String authorizationUri;
+
+		@NotBlank
+		private String stubAuthorizationUri;
+
+		@NotEmpty
+		private List<@NotBlank String> scopes = new ArrayList<>();
+
+		public static ProviderSettings defaultOpenai() {
+			ProviderSettings settings = new ProviderSettings();
+			settings.clientId = "openai-local-client";
+			settings.authorizationUri = "https://auth.openai.com/oauth/authorize";
+			settings.stubAuthorizationUri = "https://stub.openai.example.com/oauth/authorize";
+			settings.scopes = new ArrayList<>(List.of("openid", "profile"));
+			return settings;
+		}
+
+		public static ProviderSettings defaultGemini() {
+			ProviderSettings settings = new ProviderSettings();
+			settings.clientId = "gemini-local-client";
+			settings.authorizationUri = "https://accounts.google.com/o/oauth2/v2/auth";
+			settings.stubAuthorizationUri = "https://stub.gemini.example.com/oauth/authorize";
+			settings.scopes = new ArrayList<>(List.of("openid", "profile"));
+			return settings;
+		}
+
+		public String getClientId() {
+			return clientId;
+		}
+
+		public void setClientId(String clientId) {
+			this.clientId = clientId;
+		}
+
+		public String getAuthorizationUri() {
+			return authorizationUri;
+		}
+
+		public void setAuthorizationUri(String authorizationUri) {
+			this.authorizationUri = authorizationUri;
+		}
+
+		public String getStubAuthorizationUri() {
+			return stubAuthorizationUri;
+		}
+
+		public void setStubAuthorizationUri(String stubAuthorizationUri) {
+			this.stubAuthorizationUri = stubAuthorizationUri;
+		}
+
+		public List<String> getScopes() {
+			return scopes;
+		}
+
+		public void setScopes(List<String> scopes) {
+			this.scopes = scopes == null ? new ArrayList<>() : new ArrayList<>(scopes);
+		}
+	}
+
+	private void validateCallbackBaseUrl(String callbackBaseUrl) {
+		if (callbackBaseUrl == null || callbackBaseUrl.isBlank()) {
+			throw new IllegalArgumentException("callbackBaseUrl must not be blank");
+		}
+		try {
+			URI uri = new URI(callbackBaseUrl);
+			if (!uri.isAbsolute() || uri.getHost() == null) {
+				throw new IllegalArgumentException("callbackBaseUrl must be an absolute URI");
+			}
+			String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+			if (!"http".equals(scheme) && !"https".equals(scheme)) {
+				throw new IllegalArgumentException("callbackBaseUrl must use http or https");
+			}
+		} catch (URISyntaxException exception) {
+			throw new IllegalArgumentException("callbackBaseUrl must be a valid URI");
+		}
+	}
+}

--- a/src/main/java/com/logcopilot/llm/LlmOAuthProperties.java
+++ b/src/main/java/com/logcopilot/llm/LlmOAuthProperties.java
@@ -1,5 +1,6 @@
 package com.logcopilot.llm;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -72,7 +73,6 @@ public class LlmOAuthProperties {
 		if (mode == null) {
 			throw new IllegalArgumentException("mode must not be null");
 		}
-		validateLiveModeCallbackBaseUrl(mode, callbackBaseUrl);
 		this.mode = mode;
 	}
 
@@ -236,5 +236,11 @@ public class LlmOAuthProperties {
 			|| "::1".equals(host)
 			|| "0:0:0:0:0:0:0:1".equals(host)
 			|| host.startsWith("127.");
+	}
+
+	@PostConstruct
+	void validateResolvedConfiguration() {
+		validateCallbackBaseUrl(callbackBaseUrl);
+		validateLiveModeCallbackBaseUrl(mode, callbackBaseUrl);
 	}
 }

--- a/src/main/java/com/logcopilot/llm/LlmOAuthProperties.java
+++ b/src/main/java/com/logcopilot/llm/LlmOAuthProperties.java
@@ -69,6 +69,10 @@ public class LlmOAuthProperties {
 	}
 
 	public void setMode(Mode mode) {
+		if (mode == null) {
+			throw new IllegalArgumentException("mode must not be null");
+		}
+		validateLiveModeCallbackBaseUrl(mode, callbackBaseUrl);
 		this.mode = mode;
 	}
 
@@ -93,6 +97,7 @@ public class LlmOAuthProperties {
 
 	public void setCallbackBaseUrl(String callbackBaseUrl) {
 		validateCallbackBaseUrl(callbackBaseUrl);
+		validateLiveModeCallbackBaseUrl(mode, callbackBaseUrl);
 		this.callbackBaseUrl = callbackBaseUrl;
 	}
 
@@ -101,6 +106,9 @@ public class LlmOAuthProperties {
 	}
 
 	public void setMaxStateEntries(int maxStateEntries) {
+		if (maxStateEntries <= 0) {
+			throw new IllegalArgumentException("maxStateEntries must be positive");
+		}
 		this.maxStateEntries = maxStateEntries;
 	}
 
@@ -206,5 +214,27 @@ public class LlmOAuthProperties {
 		} catch (URISyntaxException exception) {
 			throw new IllegalArgumentException("callbackBaseUrl must be a valid URI");
 		}
+	}
+
+	private void validateLiveModeCallbackBaseUrl(Mode mode, String callbackBaseUrl) {
+		if (mode != Mode.LIVE) {
+			return;
+		}
+
+		URI uri = URI.create(callbackBaseUrl);
+		String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+		String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
+		if (!"https".equals(scheme) || isLoopbackHost(host)) {
+			throw new IllegalArgumentException("LIVE mode requires https callbackBaseUrl with non-local host");
+		}
+	}
+
+	private boolean isLoopbackHost(String host) {
+		return "localhost".equals(host)
+			|| "127.0.0.1".equals(host)
+			|| "0.0.0.0".equals(host)
+			|| "::1".equals(host)
+			|| "0:0:0:0:0:0:0:1".equals(host)
+			|| host.startsWith("127.");
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=logcopilot
+logcopilot.llm.oauth.mode=stub
+logcopilot.llm.oauth.state-ttl=PT10M
+logcopilot.llm.oauth.callback-base-url=http://localhost:8080
+logcopilot.llm.oauth.openai.client-id=openai-local-client
+logcopilot.llm.oauth.openai.authorization-uri=https://auth.openai.com/oauth/authorize
+logcopilot.llm.oauth.openai.stub-authorization-uri=https://stub.openai.example.com/oauth/authorize
+logcopilot.llm.oauth.openai.scopes=openid,profile
+logcopilot.llm.oauth.gemini.client-id=gemini-local-client
+logcopilot.llm.oauth.gemini.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth
+logcopilot.llm.oauth.gemini.stub-authorization-uri=https://stub.gemini.example.com/oauth/authorize
+logcopilot.llm.oauth.gemini.scopes=openid,profile

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=logcopilot
 logcopilot.llm.oauth.mode=stub
 logcopilot.llm.oauth.state-ttl=PT10M
+logcopilot.llm.oauth.max-state-entries=10000
 logcopilot.llm.oauth.callback-base-url=http://localhost:8080
 logcopilot.llm.oauth.openai.client-id=openai-local-client
 logcopilot.llm.oauth.openai.authorization-uri=https://auth.openai.com/oauth/authorize

--- a/src/test/java/com/logcopilot/llm/LlmAccountEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmAccountEndpointsContractTest.java
@@ -218,6 +218,32 @@ class LlmAccountEndpointsContractTest {
 	}
 
 	@Test
+	@DisplayName("GET /v1/projects/{project_id}/llm-oauth/{provider}/callback 은 provider 오류를 400으로 매핑한다")
+	void callbackLlmOAuthReturns400WhenProviderReturnsError() throws Exception {
+		String projectId = createProjectId("llm-oauth-callback-provider-error");
+		MvcResult started = mockMvc.perform(post("/v1/projects/{project_id}/llm-oauth/{provider}/start", projectId, "gemini")
+				.header("Authorization", "Bearer llm-token"))
+			.andExpect(status().isOk())
+			.andReturn();
+		String state = jsonValue(started, "/data/state");
+
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", projectId, "gemini")
+				.queryParam("state", state)
+				.queryParam("error", "access_denied")
+				.queryParam("error_description", "user denied"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error.code").value("bad_request"))
+			.andExpect(jsonPath("$.error.message").value("OAuth provider returned error: access_denied (user denied)"));
+
+		mockMvc.perform(get("/v1/projects/{project_id}/llm-oauth/{provider}/callback", projectId, "gemini")
+				.queryParam("state", state)
+				.queryParam("code", "oauth-code-2"))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.error.code").value("conflict"))
+			.andExpect(jsonPath("$.error.message").value("Invalid or expired oauth state"));
+	}
+
+	@Test
 	@DisplayName("GET /v1/projects/{project_id}/llm-accounts 는 계정 목록을 반환한다")
 	void listLlmAccountsReturnsAccountList() throws Exception {
 		String projectId = createProjectId("llm-list");

--- a/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
@@ -188,15 +188,17 @@ class LlmAccountServiceTest {
 	@Test
 	@DisplayName("LlmAccountService는 state 저장소 상한 초과 시 가장 오래된 state를 제거한다")
 	void startOAuthEvictsOldestStateWhenCapacityExceeded() {
-		oauthProperties.setMaxStateEntries(2);
+		LlmOAuthProperties localProperties = LlmOAuthProperties.defaultProperties();
+		localProperties.setMaxStateEntries(2);
+		LlmAccountService localService = new LlmAccountService(projectService, localProperties, clock);
 		ProjectDto project = projectService.create("oauth-capacity-project", "prod");
-		LlmAccountService.OAuthStartResult first = llmAccountService.startOAuth(project.id(), "openai");
+		LlmAccountService.OAuthStartResult first = localService.startOAuth(project.id(), "openai");
 		clock.advance(Duration.ofSeconds(1));
-		LlmAccountService.OAuthStartResult second = llmAccountService.startOAuth(project.id(), "openai");
+		LlmAccountService.OAuthStartResult second = localService.startOAuth(project.id(), "openai");
 		clock.advance(Duration.ofSeconds(1));
-		LlmAccountService.OAuthStartResult third = llmAccountService.startOAuth(project.id(), "openai");
+		LlmAccountService.OAuthStartResult third = localService.startOAuth(project.id(), "openai");
 
-		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
+		assertThatThrownBy(() -> localService.callbackOAuth(
 			project.id(),
 			"openai",
 			"oauth-code-1",
@@ -207,7 +209,7 @@ class LlmAccountServiceTest {
 			.isInstanceOf(ConflictException.class)
 			.hasMessage("Invalid or expired oauth state");
 
-		LlmAccountService.OAuthCallbackResult callback = llmAccountService.callbackOAuth(
+		LlmAccountService.OAuthCallbackResult callback = localService.callbackOAuth(
 			project.id(),
 			"openai",
 			"oauth-code-2",
@@ -219,6 +221,31 @@ class LlmAccountServiceTest {
 		assertThat(callback.linked()).isTrue();
 		assertThat(callback.accountId()).isNotBlank();
 		assertThat(second.state()).isNotEqualTo(third.state());
+	}
+
+	@Test
+	@DisplayName("LlmAccountService는 auth URL 생성 실패 시 OAuth state를 저장하지 않는다")
+	void startOAuthDoesNotPersistStateWhenAuthorizationUrlBuildFails() {
+		LlmOAuthProperties localProperties = LlmOAuthProperties.defaultProperties();
+		localProperties.setMaxStateEntries(1);
+		localProperties.getOpenai().setStubAuthorizationUri("");
+		LlmAccountService localService = new LlmAccountService(projectService, localProperties, clock);
+		ProjectDto project = projectService.create("oauth-start-failure-project", "prod");
+		LlmAccountService.OAuthStartResult validState = localService.startOAuth(project.id(), "gemini");
+
+		assertThatThrownBy(() -> localService.startOAuth(project.id(), "openai"))
+			.isInstanceOf(BadRequestException.class)
+			.hasMessage("OAuth provider is not configured");
+
+		LlmAccountService.OAuthCallbackResult callback = localService.callbackOAuth(
+			project.id(),
+			"gemini",
+			"oauth-code-1",
+			validState.state(),
+			null,
+			null
+		);
+		assertThat(callback.linked()).isTrue();
 	}
 
 	@Test

--- a/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
@@ -9,7 +9,13 @@ import com.logcopilot.project.ProjectService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,7 +23,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class LlmAccountServiceTest {
 
 	private final ProjectService projectService = new ProjectService();
-	private final LlmAccountService llmAccountService = new LlmAccountService(projectService);
+	private final LlmOAuthProperties oauthProperties = LlmOAuthProperties.defaultProperties();
+	private final MutableClock clock = new MutableClock(Instant.parse("2026-03-04T00:00:00Z"));
+	private final LlmAccountService llmAccountService = new LlmAccountService(projectService, oauthProperties, clock);
 
 	@Test
 	@DisplayName("LlmAccountService는 API key 계정을 생성 후 같은 provider 요청을 갱신한다")
@@ -62,7 +70,9 @@ class LlmAccountServiceTest {
 			project.id(),
 			"gemini",
 			"oauth-code-1",
-			start.state()
+			start.state(),
+			null,
+			null
 		);
 
 		List<LlmAccountService.LlmAccount> accounts = llmAccountService.list(project.id());
@@ -83,7 +93,9 @@ class LlmAccountServiceTest {
 			project.id(),
 			"openai",
 			"oauth-code-1",
-			"wrong-state"
+			"wrong-state",
+			null,
+			null
 		))
 			.isInstanceOf(ConflictException.class)
 			.hasMessage("Invalid or expired oauth state");
@@ -95,16 +107,118 @@ class LlmAccountServiceTest {
 		ProjectDto project = projectService.create("oauth-reuse-project", "prod");
 		LlmAccountService.OAuthStartResult start = llmAccountService.startOAuth(project.id(), "openai");
 
-		llmAccountService.callbackOAuth(project.id(), "openai", "oauth-code-1", start.state());
+		llmAccountService.callbackOAuth(project.id(), "openai", "oauth-code-1", start.state(), null, null);
 
 		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
 			project.id(),
 			"openai",
 			"oauth-code-2",
-			start.state()
+			start.state(),
+			null,
+			null
 		))
 			.isInstanceOf(ConflictException.class)
 			.hasMessage("Invalid or expired oauth state");
+	}
+
+	@Test
+	@DisplayName("LlmAccountService는 OAuth state TTL 경계에서 만료된 state를 거부한다")
+	void callbackOAuthRejectsExpiredStateAtTtlBoundary() {
+		ProjectDto project = projectService.create("oauth-ttl-project", "prod");
+		LlmAccountService.OAuthStartResult start = llmAccountService.startOAuth(project.id(), "openai");
+		clock.advance(oauthProperties.getStateTtl());
+
+		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
+			project.id(),
+			"openai",
+			"oauth-code-1",
+			start.state(),
+			null,
+			null
+		))
+			.isInstanceOf(ConflictException.class)
+			.hasMessage("Invalid or expired oauth state");
+	}
+
+	@Test
+	@DisplayName("LlmAccountService는 provider 오류 콜백을 400으로 매핑하고 state를 재사용 불가로 만든다")
+	void callbackOAuthMapsProviderErrorAndConsumesState() {
+		ProjectDto project = projectService.create("oauth-provider-error-project", "prod");
+		LlmAccountService.OAuthStartResult start = llmAccountService.startOAuth(project.id(), "gemini");
+
+		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
+			project.id(),
+			"gemini",
+			null,
+			start.state(),
+			"access_denied",
+			"User denied"
+		))
+			.isInstanceOf(BadRequestException.class)
+			.hasMessage("OAuth provider returned error: access_denied (User denied)");
+
+		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
+			project.id(),
+			"gemini",
+			"oauth-code-2",
+			start.state(),
+			null,
+			null
+		))
+			.isInstanceOf(ConflictException.class)
+			.hasMessage("Invalid or expired oauth state");
+	}
+
+	@Test
+	@DisplayName("LlmAccountService는 OAuth start 시 provider별 프로퍼티로 auth URL을 구성한다")
+	void startOAuthBuildsAuthUrlFromProviderProperties() {
+		ProjectDto project = projectService.create("oauth-url-project", "prod");
+		LlmAccountService.OAuthStartResult start = llmAccountService.startOAuth(project.id(), "openai");
+		URI uri = URI.create(start.authUrl());
+		Map<String, String> query = QueryStringParser.parse(uri.getQuery());
+
+		assertThat(uri.getHost()).isEqualTo("stub.openai.example.com");
+		assertThat(query.get("client_id")).isEqualTo("openai-local-client");
+		assertThat(query.get("scope")).isEqualTo("openid profile");
+		assertThat(query.get("redirect_uri"))
+			.isEqualTo("http://localhost:8080/v1/projects/%s/llm-oauth/openai/callback".formatted(project.id()));
+		assertThat(query.get("state")).isEqualTo(start.state());
+	}
+
+	@Test
+	@DisplayName("LlmAccountService는 state 저장소 상한 초과 시 가장 오래된 state를 제거한다")
+	void startOAuthEvictsOldestStateWhenCapacityExceeded() {
+		oauthProperties.setMaxStateEntries(2);
+		ProjectDto project = projectService.create("oauth-capacity-project", "prod");
+		LlmAccountService.OAuthStartResult first = llmAccountService.startOAuth(project.id(), "openai");
+		clock.advance(Duration.ofSeconds(1));
+		LlmAccountService.OAuthStartResult second = llmAccountService.startOAuth(project.id(), "openai");
+		clock.advance(Duration.ofSeconds(1));
+		LlmAccountService.OAuthStartResult third = llmAccountService.startOAuth(project.id(), "openai");
+
+		assertThatThrownBy(() -> llmAccountService.callbackOAuth(
+			project.id(),
+			"openai",
+			"oauth-code-1",
+			first.state(),
+			null,
+			null
+		))
+			.isInstanceOf(ConflictException.class)
+			.hasMessage("Invalid or expired oauth state");
+
+		LlmAccountService.OAuthCallbackResult callback = llmAccountService.callbackOAuth(
+			project.id(),
+			"openai",
+			"oauth-code-2",
+			third.state(),
+			null,
+			null
+		);
+
+		assertThat(callback.linked()).isTrue();
+		assertThat(callback.accountId()).isNotBlank();
+		assertThat(second.state()).isNotEqualTo(third.state());
 	}
 
 	@Test
@@ -218,5 +332,52 @@ class LlmAccountServiceTest {
 		))
 			.isInstanceOf(ValidationException.class)
 			.hasMessage("base_url must be a valid URI");
+	}
+
+	private static final class QueryStringParser {
+
+		private QueryStringParser() {
+		}
+
+		static Map<String, String> parse(String query) {
+			return query == null || query.isBlank()
+				? Map.of()
+				: java.util.Arrays.stream(query.split("&"))
+					.map(part -> part.split("=", 2))
+					.collect(java.util.stream.Collectors.toMap(
+						pair -> java.net.URLDecoder.decode(pair[0], java.nio.charset.StandardCharsets.UTF_8),
+						pair -> pair.length > 1
+							? java.net.URLDecoder.decode(pair[1], java.nio.charset.StandardCharsets.UTF_8)
+							: ""
+					));
+		}
+	}
+
+	private static final class MutableClock extends Clock {
+
+		private Instant current;
+
+		private MutableClock(Instant current) {
+			this.current = current;
+		}
+
+		@Override
+		public ZoneOffset getZone() {
+			return ZoneOffset.UTC;
+		}
+
+		@Override
+		public Clock withZone(java.time.ZoneId zone) {
+			return this;
+		}
+
+		@Override
+		public Instant instant() {
+			return current;
+		}
+
+		void advance(Duration duration) {
+			current = current.plus(duration);
+		}
 	}
 }

--- a/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmAccountServiceTest.java
@@ -375,7 +375,8 @@ class LlmAccountServiceTest {
 						pair -> java.net.URLDecoder.decode(pair[0], java.nio.charset.StandardCharsets.UTF_8),
 						pair -> pair.length > 1
 							? java.net.URLDecoder.decode(pair[1], java.nio.charset.StandardCharsets.UTF_8)
-							: ""
+							: "",
+						(previous, current) -> current
 					));
 		}
 	}

--- a/src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java
@@ -1,0 +1,52 @@
+package com.logcopilot.llm;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LlmOAuthPropertiesTest {
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 0 이하 state TTL을 허용하지 않는다")
+	void rejectsNonPositiveStateTtl() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+
+		assertThatThrownBy(() -> properties.setStateTtl(Duration.ZERO))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("stateTtl must be positive");
+	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 절대 URI가 아닌 callback base URL을 거부한다")
+	void rejectsRelativeCallbackBaseUrl() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+
+		assertThatThrownBy(() -> properties.setCallbackBaseUrl("/relative/callback"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("callbackBaseUrl must be an absolute URI");
+	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 callback base URL에 http/https 외 스킴을 거부한다")
+	void rejectsUnsupportedCallbackBaseUrlScheme() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+
+		assertThatThrownBy(() -> properties.setCallbackBaseUrl("ftp://example.com"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("callbackBaseUrl must use http or https");
+	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 유효한 callback base URL을 허용한다")
+	void acceptsValidCallbackBaseUrl() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+
+		properties.setCallbackBaseUrl("https://logcopilot.example.com");
+
+		assertThat(properties.getCallbackBaseUrl()).isEqualTo("https://logcopilot.example.com");
+	}
+}

--- a/src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java
@@ -64,8 +64,9 @@ class LlmOAuthPropertiesTest {
 	@DisplayName("LlmOAuthProperties는 LIVE 모드에서 https와 비로컬 callback URL을 요구한다")
 	void rejectsLocalCallbackUrlWhenLiveModeEnabled() {
 		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+		properties.setMode(LlmOAuthProperties.Mode.LIVE);
 
-		assertThatThrownBy(() -> properties.setMode(LlmOAuthProperties.Mode.LIVE))
+		assertThatThrownBy(properties::validateResolvedConfiguration)
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("LIVE mode requires https callbackBaseUrl with non-local host");
 	}
@@ -79,5 +80,18 @@ class LlmOAuthPropertiesTest {
 		properties.setMode(LlmOAuthProperties.Mode.LIVE);
 
 		assertThat(properties.getMode()).isEqualTo(LlmOAuthProperties.Mode.LIVE);
+	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 LIVE 모드 설정 후 callback URL을 설정해도 유효 조합을 허용한다")
+	void acceptsLiveModeWithSecureRemoteCallbackUrlWhenModeSetFirst() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+		properties.setMode(LlmOAuthProperties.Mode.LIVE);
+
+		properties.setCallbackBaseUrl("https://logcopilot.example.com");
+		properties.validateResolvedConfiguration();
+
+		assertThat(properties.getMode()).isEqualTo(LlmOAuthProperties.Mode.LIVE);
+		assertThat(properties.getCallbackBaseUrl()).isEqualTo("https://logcopilot.example.com");
 	}
 }

--- a/src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java
+++ b/src/test/java/com/logcopilot/llm/LlmOAuthPropertiesTest.java
@@ -49,4 +49,35 @@ class LlmOAuthPropertiesTest {
 
 		assertThat(properties.getCallbackBaseUrl()).isEqualTo("https://logcopilot.example.com");
 	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 0 이하 maxStateEntries를 허용하지 않는다")
+	void rejectsNonPositiveMaxStateEntries() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+
+		assertThatThrownBy(() -> properties.setMaxStateEntries(0))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("maxStateEntries must be positive");
+	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 LIVE 모드에서 https와 비로컬 callback URL을 요구한다")
+	void rejectsLocalCallbackUrlWhenLiveModeEnabled() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+
+		assertThatThrownBy(() -> properties.setMode(LlmOAuthProperties.Mode.LIVE))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("LIVE mode requires https callbackBaseUrl with non-local host");
+	}
+
+	@Test
+	@DisplayName("LlmOAuthProperties는 LIVE 모드에서 유효한 callback URL을 허용한다")
+	void acceptsLiveModeWithSecureRemoteCallbackUrl() {
+		LlmOAuthProperties properties = LlmOAuthProperties.defaultProperties();
+		properties.setCallbackBaseUrl("https://logcopilot.example.com");
+
+		properties.setMode(LlmOAuthProperties.Mode.LIVE);
+
+		assertThat(properties.getMode()).isEqualTo(LlmOAuthProperties.Mode.LIVE);
+	}
 }


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - OAuth2(OpenAI/Gemini) start/callback 경로를 프로퍼티 기반으로 정리했다.
  - state TTL/재사용 방지/상한(eviction) 정책을 고정했다.
  - callback provider 오류(`error`, `error_description`) 매핑과 OpenAPI 계약을 동기화했다.
  - stub/live 전환 기준 문서와 T-15 세션 노트를 추가했다.
- 왜 필요한가:
  - T-15 완료 조건인 state 정책 강화와 오류 매핑 일관성을 충족해 운영 리스크를 줄이기 위해.

## 연결 이슈
- Closes #36

## 범위 점검
- 포함:
  - OAuth 설정 프로퍼티 클래스 추가
  - LLM OAuth start/callback 서비스/컨트롤러 보강
  - OpenAPI callback 파라미터 업데이트
  - OAuth mode 운영 가이드 문서화
  - 관련 unit/integration 테스트 보강
- 제외:
  - 실제 provider token exchange/issuer 검증 구현
  - Loki pull/cursor commit(T-16)

## 주요 변경 사항
- `src/main/java/com/logcopilot/llm/LlmOAuthProperties.java` 추가
- `src/main/java/com/logcopilot/llm/LlmAccountService.java` OAuth URL 생성/상태 정책/오류 메시지 개선
- `src/main/java/com/logcopilot/llm/LlmAccountController.java` callback query 확장
- `docs/api/openapi-selfhosted-byom-v1.yaml` callback 파라미터 계약 반영
- `docs/domain/oauth2-provider-modes.md` 추가

## TDD 근거
- RED:
  - `./gradlew test --tests "*LlmAccount*Test"`에서 신규 설정/시그니처 부재로 `compileTestJava` 실패 확인
- GREEN:
  - `./gradlew test --tests "*LlmAccount*Test" --tests "*OAuth*Test"` PASS
- REFACTOR:
  - fail-fast(설정 검증), state 저장소 상한, 문서 범위 명확화 반영

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC3 -> `./gradlew test --tests "*LlmAccount*Test" --tests "*OAuth*Test"` -> PASS
- AC3 -> `./gradlew test --tests "*LlmOAuthPropertiesTest"` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 대기 중
- codex:
  - 딴지 리뷰에서 제기된 설정 검증/state 상한/문서 범위 정합성 이슈 반영 완료

## 리스크 / 롤백
- 확인된 리스크:
  - live 모드의 실제 token exchange/issuer 검증은 후속 태스크 필요
- 롤백 계획:
  - 본 PR revert 시 기존 stub 중심 OAuth 경로로 즉시 복귀 가능

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-16: Loki pull collector + cursor commit + push/pull 병합


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * OAuth 콜백에서 제공자 오류(error, error_description)를 수집해 사용자에게 적절히 응답하도록 향상
  * OAuth 상태(state)에 TTL(만료 시간) 및 최대 보관 수 설정 추가
  * STUB/LIVE 모드 지원으로 테스트용 스텁과 실운영 제공자 전환 가능

* **문서**
  * OAuth2 제공자 모드 구성 가이드 추가 (모드, 콜백 정책, 구성 키 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->