### PR TITLE
[WU-16] T-16 Loki pull collector + cursor commit + push/pull 병합

### DIFF
--- a/docs/sessions/2026-03-04-T-16.md
+++ b/docs/sessions/2026-03-04-T-16.md
@@ -104,3 +104,19 @@ Use `docs/templates/commit-message.template.md`.
   - T-17
 - Suggested first check for next session:
   - LLM analyzer 직전 redaction 강제 경로에서 민감정보 로그 노출이 없는지 RED 테스트부터 고정.
+
+## 9. PR Review Follow-up (PR #39)
+- Reason:
+  - Codex/CodeRabbit 리뷰에서 cursor 전진 누락(P1), idempotency key 충돌(P2), `unknown-*` fallback 충돌 가능성 지적.
+- Changes:
+  - empty pull batch에서도 `nextCursor`를 commit하도록 collector 로직 보강.
+  - push/pull idempotency key namespace 분리(`push:` / `pull:`)로 교차 오염 방지.
+  - pull idempotency key 생성 시 `project_id`/`batch_id` 누락을 fail-fast(`ValidationException`) 처리.
+  - cursor store 계약 Javadoc 및 음수 cursor 정규화 테스트 추가.
+  - `NoopLokiPullClient`를 `@Primary`로 지정해 향후 다중 구현체 추가 시 기본 빈 선택성 확보.
+- Re-run verification:
+  - `./gradlew test --tests "*LokiPullCollectorTest" --tests "*InMemoryLokiPullCursorStoreTest" --tests "*IngestServiceTest"` => PASS
+  - `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"` => PASS
+  - `./gradlew check` => PASS
+  - `./gradlew test` => PASS
+  - `./gradlew build` => PASS

--- a/docs/sessions/2026-03-04-T-16.md
+++ b/docs/sessions/2026-03-04-T-16.md
@@ -1,0 +1,106 @@
+# Session Task Note - T-16
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #38
+- Branch: `feature/38-t16-loki-pull-cursor`
+- Task ID: T-16
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - Loki pull worker(주기 실행)와 cursor 저장 모델(in-memory)을 추가한다.
+  - pull 결과를 `CanonicalLogEvent` 기준으로 기존 ingest canonical pipeline에 병합한다.
+  - ingest/incident 반영 성공 시에만 cursor commit 되도록 보장한다.
+  - 실패/재시도/중복(batch 재처리) 일관성 회귀 테스트를 추가한다.
+- Do not do now:
+  - 실제 Loki HTTP 연동/쿼리 최적화.
+  - SQLite 영속화 전환(T-21) 및 secret 암호화 저장소 전환.
+  - UI/알림/rate-limit 후속 작업(T-17+).
+- Done means:
+  - pull 경로가 push와 동일 `IngestService` canonical 처리 경로를 사용한다.
+  - cursor commit은 ingest accepted=true인 성공 경로에서만 발생한다.
+  - 동일 pull batch 재처리 시 idempotency로 중복 incident 생성이 방지된다.
+  - `*Loki*/*Ingest*/*Incident*` 및 게이트(`check/test/build`)가 green이다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction -> openapi -> architecture-guardrails -> workflow -> active spec` 순으로 점검.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - Loki-only 수집 경로 완성(T-16)은 MVP in-scope다.
+- AC-to-rule mapping to execute:
+  - AC4(T-16) -> Integration/Regression -> `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"` -> PASS
+  - Gate -> `./gradlew check` -> PASS
+  - Gate -> `./gradlew test` -> PASS
+  - Gate(조건부) -> `./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. RED: pull collector/cursor/pipeline merge/commit 조건 테스트를 먼저 추가해 실패를 고정한다.
+2. GREEN: `LokiPullCollector`, `LokiPullClient`, `LokiPullCursorStore`, `ingestPulledEvents`를 최소 구현한다.
+3. REFACTOR: pull idempotency key, poll_interval 반영, accepted=false non-commit 가드를 보강한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/connector/LokiPullCollectorTest.java`
+  - `src/test/java/com/logcopilot/connector/InMemoryLokiPullCursorStoreTest.java`
+  - `src/test/java/com/logcopilot/ingest/IngestServiceTest.java` (pull merge/중복 방지 케이스 추가)
+- RED failure output summary:
+  - `./gradlew test --tests "*LokiPull*Test" --tests "*IngestServiceTest"` 실행 시
+    - `LokiPullClient`, `LokiPullCursorStore`, `LokiPullCollector`, `ingestPulledEvents` 미구현 컴파일 오류 확인.
+- GREEN pass output summary:
+  - `./gradlew test --tests "*LokiPull*Test" --tests "*IngestServiceTest"` -> PASS
+  - `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"` -> PASS
+- REFACTOR summary:
+  - pull 경로 idempotency key(`pull:<project>:<batch>`)를 도입해 동일 batch 재처리 시 중복 incident를 차단.
+  - connector별 `poll_interval_seconds`를 collector 실행 판단에 반영.
+  - ingest 결과가 `accepted=false`이면 cursor를 commit하지 않도록 강화.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/connector/LokiPullCollector.java`
+  - `src/main/java/com/logcopilot/connector/LokiPullClient.java`
+  - `src/main/java/com/logcopilot/connector/NoopLokiPullClient.java`
+  - `src/main/java/com/logcopilot/connector/LokiPullCursorStore.java`
+  - `src/main/java/com/logcopilot/connector/InMemoryLokiPullCursorStore.java`
+  - `src/main/java/com/logcopilot/connector/LokiConnectorService.java`
+  - `src/main/java/com/logcopilot/ingest/IngestService.java`
+  - `src/main/java/com/logcopilot/LogcopilotApplication.java`
+  - `src/main/resources/application.properties`
+  - `src/test/java/com/logcopilot/connector/LokiPullCollectorTest.java`
+  - `src/test/java/com/logcopilot/connector/InMemoryLokiPullCursorStoreTest.java`
+  - `src/test/java/com/logcopilot/ingest/IngestServiceTest.java`
+- Why this approach:
+  - 기존 공개 API 계약을 변경하지 않고, 내부 수집 경로만 추가해 T-16 목표(pull 병합 + cursor commit 조건)를 최소 변경으로 충족한다.
+  - `IngestService`를 push/pull 공통 진입점으로 유지해 architecture guardrail의 canonical pipeline 일원화 원칙을 지킨다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*LokiPull*Test" --tests "*IngestServiceTest"`
+  - `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"`
+  - `./gradlew check`
+  - `./gradlew test`
+  - `./gradlew build`
+- Results:
+  - RED 컴파일 실패 확인 후 GREEN/REFACTOR 단계에서 모두 PASS.
+  - 주의: `check/test/build`를 병렬 실행했을 때 test report XML 충돌이 있었고, 순차 재실행으로 green 확인.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Explorer sub-agent `Popper`
+- Findings:
+  - pull 경로 idempotency 누락 시 중복 incident 위험.
+  - `poll_interval_seconds` 런타임 미반영.
+  - 재시도/중복 일관성 테스트 보강 필요.
+- Resolution:
+  - `ingestPulledEvents`에 pull batch 기반 idempotency key 적용.
+  - `LokiPullCollector`에 connector별 poll interval 판정 로직 반영.
+  - `accepted=false` non-commit 및 동일 batch 재처리 중복 방지 테스트 추가.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - 현재 `NoopLokiPullClient`는 실제 Loki API 호출/정규화 매핑이 없으므로, T-21 이전에 영속 cursor와 함께 실연동 보강이 필요.
+- Next task ID:
+  - T-17
+- Suggested first check for next session:
+  - LLM analyzer 직전 redaction 강제 경로에서 민감정보 로그 노출이 없는지 RED 테스트부터 고정.

--- a/src/main/java/com/logcopilot/LogcopilotApplication.java
+++ b/src/main/java/com/logcopilot/LogcopilotApplication.java
@@ -2,8 +2,10 @@ package com.logcopilot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class LogcopilotApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/logcopilot/connector/InMemoryLokiPullCursorStore.java
+++ b/src/main/java/com/logcopilot/connector/InMemoryLokiPullCursorStore.java
@@ -1,0 +1,23 @@
+package com.logcopilot.connector;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class InMemoryLokiPullCursorStore implements LokiPullCursorStore {
+
+	private final Map<String, Long> cursorByProjectId = new HashMap<>();
+
+	@Override
+	public synchronized long readCursor(String projectId) {
+		return cursorByProjectId.getOrDefault(projectId, 0L);
+	}
+
+	@Override
+	public synchronized void commit(String projectId, long nextCursor) {
+		long normalizedCursor = Math.max(0L, nextCursor);
+		cursorByProjectId.merge(projectId, normalizedCursor, Math::max);
+	}
+}

--- a/src/main/java/com/logcopilot/connector/LokiConnectorService.java
+++ b/src/main/java/com/logcopilot/connector/LokiConnectorService.java
@@ -12,7 +12,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -76,6 +78,14 @@ public class LokiConnectorService {
 
 		// TODO(T-04): 하드코딩 응답 대신 실제 Loki 조회 결과를 반환해야 한다.
 		return new LokiTestResult(true, 12, 37, "Loki connector test succeeded");
+	}
+
+	public synchronized Optional<LokiConnector> findByProjectId(String projectId) {
+		return Optional.ofNullable(connectorByProjectId.get(projectId));
+	}
+
+	public synchronized List<String> listConfiguredProjectIds() {
+		return List.copyOf(connectorByProjectId.keySet());
 	}
 
 	private void requireProject(String projectId) {

--- a/src/main/java/com/logcopilot/connector/LokiPullClient.java
+++ b/src/main/java/com/logcopilot/connector/LokiPullClient.java
@@ -1,0 +1,17 @@
+package com.logcopilot.connector;
+
+import com.logcopilot.ingest.domain.CanonicalLogEvent;
+
+import java.util.List;
+
+public interface LokiPullClient {
+
+	PullBatch pull(String projectId, LokiConnectorService.LokiConnector connector, long cursor);
+
+	record PullBatch(
+		String batchId,
+		long nextCursor,
+		List<CanonicalLogEvent> events
+	) {
+	}
+}

--- a/src/main/java/com/logcopilot/connector/LokiPullCollector.java
+++ b/src/main/java/com/logcopilot/connector/LokiPullCollector.java
@@ -60,7 +60,12 @@ public class LokiPullCollector {
 		long committedCursor = lokiPullCursorStore.readCursor(projectId);
 		try {
 			LokiPullClient.PullBatch pullBatch = lokiPullClient.pull(projectId, connector.get(), committedCursor);
-			if (pullBatch == null || pullBatch.events() == null || pullBatch.events().isEmpty()) {
+			if (pullBatch == null) {
+				return;
+			}
+
+			if (pullBatch.events() == null || pullBatch.events().isEmpty()) {
+				lokiPullCursorStore.commit(projectId, pullBatch.nextCursor());
 				lastPulledAtByProjectId.put(projectId, now);
 				return;
 			}

--- a/src/main/java/com/logcopilot/connector/LokiPullCollector.java
+++ b/src/main/java/com/logcopilot/connector/LokiPullCollector.java
@@ -1,0 +1,99 @@
+package com.logcopilot.connector;
+
+import com.logcopilot.ingest.IngestService;
+import com.logcopilot.ingest.domain.IngestAcceptedResult;
+import com.logcopilot.ingest.domain.CanonicalLogEvent;
+import com.logcopilot.ingest.domain.IngestEventsCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class LokiPullCollector {
+
+	private static final Logger logger = LoggerFactory.getLogger(LokiPullCollector.class);
+
+	private final LokiConnectorService lokiConnectorService;
+	private final LokiPullClient lokiPullClient;
+	private final LokiPullCursorStore lokiPullCursorStore;
+	private final IngestService ingestService;
+	private final Map<String, Instant> lastPulledAtByProjectId = new HashMap<>();
+
+	public LokiPullCollector(
+		LokiConnectorService lokiConnectorService,
+		LokiPullClient lokiPullClient,
+		LokiPullCursorStore lokiPullCursorStore,
+		IngestService ingestService
+	) {
+		this.lokiConnectorService = lokiConnectorService;
+		this.lokiPullClient = lokiPullClient;
+		this.lokiPullCursorStore = lokiPullCursorStore;
+		this.ingestService = ingestService;
+	}
+
+	@Scheduled(fixedDelayString = "${logcopilot.loki.pull.fixed-delay-ms:30000}")
+	public void collectConfiguredProjects() {
+		for (String projectId : lokiConnectorService.listConfiguredProjectIds()) {
+			collectProject(projectId);
+		}
+	}
+
+	synchronized void collectProject(String projectId) {
+		Optional<LokiConnectorService.LokiConnector> connector = lokiConnectorService.findByProjectId(projectId);
+		if (connector.isEmpty()) {
+			return;
+		}
+
+		Instant now = Instant.now();
+		if (!isDue(projectId, connector.get().pollIntervalSeconds(), now)) {
+			return;
+		}
+
+		long committedCursor = lokiPullCursorStore.readCursor(projectId);
+		try {
+			LokiPullClient.PullBatch pullBatch = lokiPullClient.pull(projectId, connector.get(), committedCursor);
+			if (pullBatch == null || pullBatch.events() == null || pullBatch.events().isEmpty()) {
+				lastPulledAtByProjectId.put(projectId, now);
+				return;
+			}
+
+			List<CanonicalLogEvent> events = pullBatch.events();
+			String batchId = normalizeBatchId(pullBatch.batchId());
+			IngestAcceptedResult acceptedResult = ingestService.ingestPulledEvents(new IngestEventsCommand(
+				projectId,
+				"loki",
+				batchId,
+				events
+			));
+			if (acceptedResult.accepted()) {
+				lokiPullCursorStore.commit(projectId, pullBatch.nextCursor());
+				lastPulledAtByProjectId.put(projectId, now);
+			}
+		} catch (RuntimeException exception) {
+			logger.warn("Loki pull failed for project_id={}", projectId, exception);
+		}
+	}
+
+	private boolean isDue(String projectId, int pollIntervalSeconds, Instant now) {
+		Instant lastPulledAt = lastPulledAtByProjectId.get(projectId);
+		if (lastPulledAt == null) {
+			return true;
+		}
+		return !lastPulledAt.plusSeconds(Math.max(1, pollIntervalSeconds)).isAfter(now);
+	}
+
+	private String normalizeBatchId(String batchId) {
+		if (batchId == null || batchId.isBlank()) {
+			return "pull-" + UUID.randomUUID();
+		}
+		return batchId;
+	}
+}

--- a/src/main/java/com/logcopilot/connector/LokiPullCursorStore.java
+++ b/src/main/java/com/logcopilot/connector/LokiPullCursorStore.java
@@ -1,8 +1,20 @@
 package com.logcopilot.connector;
 
+/**
+ * Stores committed Loki pull cursors per project.
+ * Implementations should preserve monotonic progress semantics.
+ */
 public interface LokiPullCursorStore {
 
+	/**
+	 * Returns the latest committed cursor for a project.
+	 * Implementations should return {@code 0} when no cursor exists.
+	 */
 	long readCursor(String projectId);
 
+	/**
+	 * Commits the next cursor for a project.
+	 * Implementations should keep cursor monotonic (non-decreasing) and normalize negative values.
+	 */
 	void commit(String projectId, long nextCursor);
 }

--- a/src/main/java/com/logcopilot/connector/LokiPullCursorStore.java
+++ b/src/main/java/com/logcopilot/connector/LokiPullCursorStore.java
@@ -1,0 +1,8 @@
+package com.logcopilot.connector;
+
+public interface LokiPullCursorStore {
+
+	long readCursor(String projectId);
+
+	void commit(String projectId, long nextCursor);
+}

--- a/src/main/java/com/logcopilot/connector/NoopLokiPullClient.java
+++ b/src/main/java/com/logcopilot/connector/NoopLokiPullClient.java
@@ -1,10 +1,12 @@
 package com.logcopilot.connector;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
+@Primary
 public class NoopLokiPullClient implements LokiPullClient {
 
 	@Override

--- a/src/main/java/com/logcopilot/connector/NoopLokiPullClient.java
+++ b/src/main/java/com/logcopilot/connector/NoopLokiPullClient.java
@@ -1,0 +1,18 @@
+package com.logcopilot.connector;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class NoopLokiPullClient implements LokiPullClient {
+
+	@Override
+	public PullBatch pull(String projectId, LokiConnectorService.LokiConnector connector, long cursor) {
+		return new PullBatch(
+			"loki-pull-" + projectId + "-" + cursor,
+			cursor,
+			List.of()
+		);
+	}
+}

--- a/src/main/java/com/logcopilot/ingest/IngestService.java
+++ b/src/main/java/com/logcopilot/ingest/IngestService.java
@@ -1,6 +1,7 @@
 package com.logcopilot.ingest;
 
 import com.logcopilot.common.error.NotImplementedException;
+import com.logcopilot.common.error.ValidationException;
 import com.logcopilot.ingest.domain.EventDeduplicationPolicy;
 import com.logcopilot.ingest.domain.IngestAcceptedResult;
 import com.logcopilot.ingest.domain.IngestEventsCommand;
@@ -35,7 +36,7 @@ public class IngestService {
 	}
 
 	public IngestAcceptedResult ingestEvents(String idempotencyKey, IngestEventsCommand request) {
-		return idempotencyStore.computeIfAbsent(idempotencyKey, ignored -> ingestIntoCanonicalPipeline(request));
+		return idempotencyStore.computeIfAbsent(pushIdempotencyKey(idempotencyKey), ignored -> ingestIntoCanonicalPipeline(request));
 	}
 
 	public IngestAcceptedResult ingestPulledEvents(IngestEventsCommand request) {
@@ -63,8 +64,19 @@ public class IngestService {
 	}
 
 	private String pullIdempotencyKey(IngestEventsCommand request) {
-		String projectId = request == null || request.projectId() == null ? "unknown-project" : request.projectId().trim();
-		String batchId = request == null || request.batchId() == null ? "unknown-batch" : request.batchId().trim();
+		if (request == null || request.projectId() == null || request.projectId().trim().isEmpty()) {
+			throw new ValidationException("project_id is required for pulled ingest");
+		}
+		if (request.batchId() == null || request.batchId().trim().isEmpty()) {
+			throw new ValidationException("batch_id is required for pulled ingest");
+		}
+
+		String projectId = request.projectId().trim();
+		String batchId = request.batchId().trim();
 		return "pull:" + projectId + ":" + batchId;
+	}
+
+	private String pushIdempotencyKey(String idempotencyKey) {
+		return "push:" + idempotencyKey;
 	}
 }

--- a/src/main/java/com/logcopilot/ingest/IngestService.java
+++ b/src/main/java/com/logcopilot/ingest/IngestService.java
@@ -35,23 +35,36 @@ public class IngestService {
 	}
 
 	public IngestAcceptedResult ingestEvents(String idempotencyKey, IngestEventsCommand request) {
-		return idempotencyStore.computeIfAbsent(idempotencyKey, ignored -> {
-			boolean projectExists = projectService.existsById(request.projectId());
-			ingestRequestValidator.validate(request, projectExists);
-			int receivedEvents = request.events().size();
-			int deduplicatedEvents = eventDeduplicationPolicy.countDeduplicatedEvents(request.events());
-			incidentService.recordIngestedEvents(request.projectId(), request.events());
+		return idempotencyStore.computeIfAbsent(idempotencyKey, ignored -> ingestIntoCanonicalPipeline(request));
+	}
 
-			return new IngestAcceptedResult(
-				true,
-				UUID.randomUUID().toString(),
-				receivedEvents,
-				deduplicatedEvents
-			);
-		});
+	public IngestAcceptedResult ingestPulledEvents(IngestEventsCommand request) {
+		String idempotencyKey = pullIdempotencyKey(request);
+		return idempotencyStore.computeIfAbsent(idempotencyKey, ignored -> ingestIntoCanonicalPipeline(request));
 	}
 
 	public IngestAcceptedResult ingestOtlpLogs(String idempotencyKey, byte[] payload) {
 		throw new NotImplementedException("OTLP ingest endpoint is reserved in MVP");
+	}
+
+	private IngestAcceptedResult ingestIntoCanonicalPipeline(IngestEventsCommand request) {
+		boolean projectExists = projectService.existsById(request.projectId());
+		ingestRequestValidator.validate(request, projectExists);
+		int receivedEvents = request.events().size();
+		int deduplicatedEvents = eventDeduplicationPolicy.countDeduplicatedEvents(request.events());
+		incidentService.recordIngestedEvents(request.projectId(), request.events());
+
+		return new IngestAcceptedResult(
+			true,
+			UUID.randomUUID().toString(),
+			receivedEvents,
+			deduplicatedEvents
+		);
+	}
+
+	private String pullIdempotencyKey(IngestEventsCommand request) {
+		String projectId = request == null || request.projectId() == null ? "unknown-project" : request.projectId().trim();
+		String batchId = request == null || request.batchId() == null ? "unknown-batch" : request.batchId().trim();
+		return "pull:" + projectId + ":" + batchId;
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,4 @@ logcopilot.llm.oauth.gemini.client-id=gemini-local-client
 logcopilot.llm.oauth.gemini.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth
 logcopilot.llm.oauth.gemini.stub-authorization-uri=https://stub.gemini.example.com/oauth/authorize
 logcopilot.llm.oauth.gemini.scopes=openid,profile
+logcopilot.loki.pull.fixed-delay-ms=30000

--- a/src/test/java/com/logcopilot/connector/InMemoryLokiPullCursorStoreTest.java
+++ b/src/test/java/com/logcopilot/connector/InMemoryLokiPullCursorStoreTest.java
@@ -26,4 +26,15 @@ class InMemoryLokiPullCursorStoreTest {
 
 		assertThat(store.readCursor("project-1")).isEqualTo(12L);
 	}
+
+	@Test
+	@DisplayName("InMemoryLokiPullCursorStore는 음수 cursor commit 입력을 0으로 정규화한다")
+	void normalizesNegativeCursorCommit() {
+		InMemoryLokiPullCursorStore store = new InMemoryLokiPullCursorStore();
+
+		store.commit("project-1", 7L);
+		store.commit("project-1", -1L);
+
+		assertThat(store.readCursor("project-1")).isEqualTo(7L);
+	}
 }

--- a/src/test/java/com/logcopilot/connector/InMemoryLokiPullCursorStoreTest.java
+++ b/src/test/java/com/logcopilot/connector/InMemoryLokiPullCursorStoreTest.java
@@ -1,0 +1,29 @@
+package com.logcopilot.connector;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryLokiPullCursorStoreTest {
+
+	@Test
+	@DisplayName("InMemoryLokiPullCursorStore는 초기 cursor를 0으로 반환한다")
+	void returnsZeroWhenCursorMissing() {
+		InMemoryLokiPullCursorStore store = new InMemoryLokiPullCursorStore();
+
+		assertThat(store.readCursor("project-1")).isZero();
+	}
+
+	@Test
+	@DisplayName("InMemoryLokiPullCursorStore는 더 큰 cursor만 commit해 역행을 방지한다")
+	void keepsLargestCommittedCursor() {
+		InMemoryLokiPullCursorStore store = new InMemoryLokiPullCursorStore();
+
+		store.commit("project-1", 10L);
+		store.commit("project-1", 5L);
+		store.commit("project-1", 12L);
+
+		assertThat(store.readCursor("project-1")).isEqualTo(12L);
+	}
+}

--- a/src/test/java/com/logcopilot/connector/LokiPullCollectorTest.java
+++ b/src/test/java/com/logcopilot/connector/LokiPullCollectorTest.java
@@ -1,0 +1,199 @@
+package com.logcopilot.connector;
+
+import com.logcopilot.ingest.IngestService;
+import com.logcopilot.ingest.domain.CanonicalLogEvent;
+import com.logcopilot.ingest.domain.IngestAcceptedResult;
+import com.logcopilot.ingest.domain.IngestEventsCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LokiPullCollectorTest {
+
+	@Mock
+	private LokiConnectorService lokiConnectorService;
+
+	@Mock
+	private LokiPullClient lokiPullClient;
+
+	@Mock
+	private LokiPullCursorStore lokiPullCursorStore;
+
+	@Mock
+	private IngestService ingestService;
+
+	@InjectMocks
+	private LokiPullCollector lokiPullCollector;
+
+	@Test
+	@DisplayName("LokiPullCollector는 pull 성공 시 canonical ingest 후 cursor를 commit한다")
+	void commitsCursorAfterSuccessfulIngest() {
+		LokiConnectorService.LokiConnector connector = connector();
+		LokiPullClient.PullBatch pullBatch = new LokiPullClient.PullBatch(
+			"batch-1",
+			15L,
+			List.of(event("evt-1"))
+		);
+
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.of(connector));
+		when(lokiPullCursorStore.readCursor("project-1")).thenReturn(10L);
+		when(lokiPullClient.pull("project-1", connector, 10L)).thenReturn(pullBatch);
+		when(ingestService.ingestPulledEvents(any(IngestEventsCommand.class)))
+			.thenReturn(new IngestAcceptedResult(true, "ing-1", 1, 0));
+
+		lokiPullCollector.collectProject("project-1");
+
+		ArgumentCaptor<IngestEventsCommand> commandCaptor = ArgumentCaptor.forClass(IngestEventsCommand.class);
+		verify(ingestService).ingestPulledEvents(commandCaptor.capture());
+		verify(lokiPullCursorStore).commit("project-1", 15L);
+
+		IngestEventsCommand forwarded = commandCaptor.getValue();
+		assertThat(forwarded.projectId()).isEqualTo("project-1");
+		assertThat(forwarded.source()).isEqualTo("loki");
+		assertThat(forwarded.batchId()).isEqualTo("batch-1");
+		assertThat(forwarded.events()).containsExactly(event("evt-1"));
+	}
+
+	@Test
+	@DisplayName("LokiPullCollector는 ingest 실패 시 cursor를 commit하지 않는다")
+	void doesNotCommitCursorWhenIngestFails() {
+		LokiConnectorService.LokiConnector connector = connector();
+		LokiPullClient.PullBatch pullBatch = new LokiPullClient.PullBatch(
+			"batch-1",
+			21L,
+			List.of(event("evt-1"))
+		);
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.of(connector));
+		when(lokiPullCursorStore.readCursor("project-1")).thenReturn(20L);
+		when(lokiPullClient.pull("project-1", connector, 20L)).thenReturn(pullBatch);
+		doThrow(new RuntimeException("ingest failed"))
+			.when(ingestService).ingestPulledEvents(any(IngestEventsCommand.class));
+
+		lokiPullCollector.collectProject("project-1");
+
+		verify(lokiPullCursorStore, never()).commit(eq("project-1"), anyLong());
+	}
+
+	@Test
+	@DisplayName("LokiPullCollector는 ingest accepted=false면 cursor를 commit하지 않는다")
+	void doesNotCommitCursorWhenIngestNotAccepted() {
+		LokiConnectorService.LokiConnector connector = connector();
+		LokiPullClient.PullBatch pullBatch = new LokiPullClient.PullBatch(
+			"batch-1",
+			21L,
+			List.of(event("evt-1"))
+		);
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.of(connector));
+		when(lokiPullCursorStore.readCursor("project-1")).thenReturn(20L);
+		when(lokiPullClient.pull("project-1", connector, 20L)).thenReturn(pullBatch);
+		when(ingestService.ingestPulledEvents(any(IngestEventsCommand.class)))
+			.thenReturn(new IngestAcceptedResult(false, "ing-1", 1, 0));
+
+		lokiPullCollector.collectProject("project-1");
+
+		verify(lokiPullCursorStore, never()).commit(eq("project-1"), anyLong());
+	}
+
+	@Test
+	@DisplayName("LokiPullCollector는 실패 후 재시도에서 이전 cursor를 다시 사용해 pull한다")
+	void retriesFromSameCursorAfterFailure() {
+		LokiConnectorService.LokiConnector connector = connector();
+		LokiPullClient.PullBatch pullBatch = new LokiPullClient.PullBatch(
+			"batch-2",
+			4L,
+			List.of(event("evt-1"), event("evt-1"))
+		);
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.of(connector));
+		when(lokiPullCursorStore.readCursor("project-1")).thenReturn(0L);
+		when(lokiPullClient.pull("project-1", connector, 0L)).thenReturn(pullBatch);
+		when(ingestService.ingestPulledEvents(any(IngestEventsCommand.class)))
+			.thenThrow(new RuntimeException("ingest failed"))
+			.thenReturn(new IngestAcceptedResult(true, "ing-1", 2, 1));
+
+		lokiPullCollector.collectProject("project-1");
+		lokiPullCollector.collectProject("project-1");
+
+		verify(lokiPullClient, times(2)).pull("project-1", connector, 0L);
+		verify(lokiPullCursorStore).commit("project-1", 4L);
+	}
+
+	@Test
+	@DisplayName("LokiPullCollector는 등록되지 않은 프로젝트면 pull을 수행하지 않는다")
+	void skipsWhenConnectorIsMissing() {
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.empty());
+
+		lokiPullCollector.collectProject("project-1");
+
+		verify(lokiPullCursorStore, never()).readCursor(any());
+		verify(lokiPullClient, never()).pull(any(), any(), anyLong());
+		verify(ingestService, never()).ingestPulledEvents(any());
+	}
+
+	@Test
+	@DisplayName("LokiPullCollector는 connector poll_interval_seconds 이내에는 재수집하지 않는다")
+	void respectsConnectorPollInterval() {
+		LokiConnectorService.LokiConnector connector = connector();
+		LokiPullClient.PullBatch pullBatch = new LokiPullClient.PullBatch(
+			"batch-3",
+			30L,
+			List.of(event("evt-3"))
+		);
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.of(connector));
+		when(lokiPullCursorStore.readCursor("project-1")).thenReturn(0L);
+		when(lokiPullClient.pull("project-1", connector, 0L)).thenReturn(pullBatch);
+		when(ingestService.ingestPulledEvents(any(IngestEventsCommand.class)))
+			.thenReturn(new IngestAcceptedResult(true, "ing-3", 1, 0));
+
+		lokiPullCollector.collectProject("project-1");
+		lokiPullCollector.collectProject("project-1");
+
+		verify(lokiPullClient, times(1)).pull("project-1", connector, 0L);
+		verify(lokiPullCursorStore, times(1)).commit("project-1", 30L);
+	}
+
+	private LokiConnectorService.LokiConnector connector() {
+		return new LokiConnectorService.LokiConnector(
+			"connector-1",
+			"https://loki.example.com",
+			"tenant-a",
+			new LokiConnectorService.LokiAuth("none", null, null, null),
+			"{service=\"api\"}",
+			30,
+			Instant.parse("2026-03-04T03:00:00Z")
+		);
+	}
+
+	private CanonicalLogEvent event(String eventId) {
+		return new CanonicalLogEvent(
+			eventId,
+			"2026-03-04T03:00:00Z",
+			"api",
+			"error",
+			"boom",
+			null,
+			null,
+			null,
+			Map.of("cluster", "prod")
+		);
+	}
+}

--- a/src/test/java/com/logcopilot/connector/LokiPullCollectorTest.java
+++ b/src/test/java/com/logcopilot/connector/LokiPullCollectorTest.java
@@ -171,6 +171,25 @@ class LokiPullCollectorTest {
 		verify(lokiPullCursorStore, times(1)).commit("project-1", 30L);
 	}
 
+	@Test
+	@DisplayName("LokiPullCollector는 이벤트가 없는 성공 pull에서도 next cursor를 commit한다")
+	void commitsCursorForEmptySuccessfulPullBatch() {
+		LokiConnectorService.LokiConnector connector = connector();
+		LokiPullClient.PullBatch pullBatch = new LokiPullClient.PullBatch(
+			"batch-empty",
+			25L,
+			List.of()
+		);
+		when(lokiConnectorService.findByProjectId("project-1")).thenReturn(Optional.of(connector));
+		when(lokiPullCursorStore.readCursor("project-1")).thenReturn(20L);
+		when(lokiPullClient.pull("project-1", connector, 20L)).thenReturn(pullBatch);
+
+		lokiPullCollector.collectProject("project-1");
+
+		verify(ingestService, never()).ingestPulledEvents(any());
+		verify(lokiPullCursorStore).commit("project-1", 25L);
+	}
+
 	private LokiConnectorService.LokiConnector connector() {
 		return new LokiConnectorService.LokiConnector(
 			"connector-1",

--- a/src/test/java/com/logcopilot/ingest/IngestServiceTest.java
+++ b/src/test/java/com/logcopilot/ingest/IngestServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.Function;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -126,6 +128,52 @@ class IngestServiceTest {
 			.hasMessage("events size must be between 1 and 5000");
 		verify(eventDeduplicationPolicy, never()).countDeduplicatedEvents(any());
 		verify(incidentService, never()).recordIngestedEvents(any(), any());
+	}
+
+	@Test
+	@DisplayName("IngestService는 pull 이벤트를 push와 동일 canonical pipeline으로 처리한다")
+	void ingestsPulledEventsThroughSameCanonicalPipeline() {
+		IngestEventsCommand request = validRequest();
+		when(idempotencyStore.computeIfAbsent(eq("pull:project-1:batch-1"), any())).thenAnswer(invocation -> {
+			Function<String, IngestAcceptedResult> mapper = invocation.getArgument(1);
+			return mapper.apply("pull:project-1:batch-1");
+		});
+		when(projectService.existsById("project-1")).thenReturn(true);
+		doNothing().when(ingestRequestValidator).validate(request, true);
+		when(eventDeduplicationPolicy.countDeduplicatedEvents(request.events())).thenReturn(1);
+
+		IngestAcceptedResult result = ingestService.ingestPulledEvents(request);
+
+		assertThat(result.accepted()).isTrue();
+		assertThat(result.receivedEvents()).isEqualTo(2);
+		assertThat(result.deduplicatedEvents()).isEqualTo(1);
+		assertThat(result.ingestionId()).isNotBlank();
+		verify(idempotencyStore).computeIfAbsent(eq("pull:project-1:batch-1"), any());
+		verify(projectService).existsById("project-1");
+		verify(ingestRequestValidator).validate(request, true);
+		verify(eventDeduplicationPolicy).countDeduplicatedEvents(request.events());
+		verify(incidentService).recordIngestedEvents("project-1", request.events());
+	}
+
+	@Test
+	@DisplayName("IngestService는 동일 pull batch를 재처리할 때 idempotency로 중복 incident 생성을 방지한다")
+	void avoidsDuplicateIncidentCreationForSamePullBatch() {
+		IngestEventsCommand request = validRequest();
+		Map<String, IngestAcceptedResult> cachedByKey = new HashMap<>();
+		when(idempotencyStore.computeIfAbsent(eq("pull:project-1:batch-1"), any())).thenAnswer(invocation -> {
+			String key = invocation.getArgument(0);
+			Function<String, IngestAcceptedResult> mapper = invocation.getArgument(1);
+			return cachedByKey.computeIfAbsent(key, mapper);
+		});
+		when(projectService.existsById("project-1")).thenReturn(true);
+		doNothing().when(ingestRequestValidator).validate(request, true);
+		when(eventDeduplicationPolicy.countDeduplicatedEvents(request.events())).thenReturn(1);
+
+		IngestAcceptedResult first = ingestService.ingestPulledEvents(request);
+		IngestAcceptedResult second = ingestService.ingestPulledEvents(request);
+
+		assertThat(second.ingestionId()).isEqualTo(first.ingestionId());
+		verify(incidentService, times(1)).recordIngestedEvents("project-1", request.events());
 	}
 
 	private IngestEventsCommand validRequest() {

--- a/src/test/java/com/logcopilot/ingest/IngestServiceTest.java
+++ b/src/test/java/com/logcopilot/ingest/IngestServiceTest.java
@@ -58,7 +58,7 @@ class IngestServiceTest {
 	void returnsCachedAcceptedResultWhenIdempotencyKeyExists() {
 		IngestEventsCommand request = validRequest();
 		IngestAcceptedResult cached = new IngestAcceptedResult(true, "ing-1", 2, 1);
-		when(idempotencyStore.computeIfAbsent(eq("key-1"), any())).thenReturn(cached);
+		when(idempotencyStore.computeIfAbsent(eq("push:key-1"), any())).thenReturn(cached);
 
 		IngestAcceptedResult result = ingestService.ingestEvents("key-1", request);
 
@@ -72,9 +72,9 @@ class IngestServiceTest {
 	@DisplayName("IngestService는 신규 idempotency key면 검증 후 결과를 계산한다")
 	void validatesAndBuildsAcceptedResultOnFirstRequest() {
 		IngestEventsCommand request = validRequest();
-		when(idempotencyStore.computeIfAbsent(eq("key-1"), any())).thenAnswer(invocation -> {
+		when(idempotencyStore.computeIfAbsent(eq("push:key-1"), any())).thenAnswer(invocation -> {
 			Function<String, IngestAcceptedResult> mapper = invocation.getArgument(1);
-			return mapper.apply("key-1");
+			return mapper.apply("push:key-1");
 		});
 		when(projectService.existsById("project-1")).thenReturn(true);
 		doNothing().when(ingestRequestValidator).validate(request, true);
@@ -96,9 +96,9 @@ class IngestServiceTest {
 	@DisplayName("IngestService는 프로젝트가 존재하지 않을 때 검증 예외를 전파한다")
 	void propagatesValidationExceptionWhenProjectMissing() {
 		IngestEventsCommand request = validRequest();
-		when(idempotencyStore.computeIfAbsent(eq("key-1"), any())).thenAnswer(invocation -> {
+		when(idempotencyStore.computeIfAbsent(eq("push:key-1"), any())).thenAnswer(invocation -> {
 			Function<String, IngestAcceptedResult> mapper = invocation.getArgument(1);
-			return mapper.apply("key-1");
+			return mapper.apply("push:key-1");
 		});
 		when(projectService.existsById("project-1")).thenReturn(false);
 		doThrow(new ValidationException("project_id must reference an existing project"))
@@ -115,9 +115,9 @@ class IngestServiceTest {
 	@DisplayName("IngestService는 요청 검증 실패 예외를 그대로 전파한다")
 	void propagatesValidationExceptionWhenRequestInvalid() {
 		IngestEventsCommand request = validRequest();
-		when(idempotencyStore.computeIfAbsent(eq("key-1"), any())).thenAnswer(invocation -> {
+		when(idempotencyStore.computeIfAbsent(eq("push:key-1"), any())).thenAnswer(invocation -> {
 			Function<String, IngestAcceptedResult> mapper = invocation.getArgument(1);
-			return mapper.apply("key-1");
+			return mapper.apply("push:key-1");
 		});
 		when(projectService.existsById("project-1")).thenReturn(true);
 		doThrow(new ValidationException("events size must be between 1 and 5000"))
@@ -128,6 +128,38 @@ class IngestServiceTest {
 			.hasMessage("events size must be between 1 and 5000");
 		verify(eventDeduplicationPolicy, never()).countDeduplicatedEvents(any());
 		verify(incidentService, never()).recordIngestedEvents(any(), any());
+	}
+
+	@Test
+	@DisplayName("IngestService는 pull ingest에서 project_id 누락 시 fail-fast 한다")
+	void failsFastWhenPulledProjectIdMissing() {
+		IngestEventsCommand request = new IngestEventsCommand(
+			" ",
+			"loki",
+			"batch-1",
+			List.of()
+		);
+
+		assertThatThrownBy(() -> ingestService.ingestPulledEvents(request))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("project_id is required for pulled ingest");
+		verify(idempotencyStore, never()).computeIfAbsent(any(), any());
+	}
+
+	@Test
+	@DisplayName("IngestService는 pull ingest에서 batch_id 누락 시 fail-fast 한다")
+	void failsFastWhenPulledBatchIdMissing() {
+		IngestEventsCommand request = new IngestEventsCommand(
+			"project-1",
+			"loki",
+			" ",
+			List.of()
+		);
+
+		assertThatThrownBy(() -> ingestService.ingestPulledEvents(request))
+			.isInstanceOf(ValidationException.class)
+			.hasMessage("batch_id is required for pulled ingest");
+		verify(idempotencyStore, never()).computeIfAbsent(any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - Loki pull collector/cursor 모델을 추가하고 pull 결과를 기존 canonical ingest pipeline으로 병합했습니다.
  - pull batch idempotency, poll_interval 반영, success-only cursor commit 규칙을 적용했습니다.
  - T-16 회귀 테스트(성공/실패/accepted=false/재시도/중복/poll interval)를 추가했습니다.
- 왜 필요한가:
  - T-16 완료조건(AC4)인 "pull 병합 + 성공 시 cursor commit"을 계약대로 충족하기 위해 필요합니다.

## 연결 이슈
- Closes #38

## 범위 점검
- 포함:
  - pull worker(스케줄), cursor store(in-memory), pull client(noop), pipeline merge
  - IngestService pull 진입점/idempotency
  - 테스트/세션노트 업데이트
- 제외:
  - 실제 Loki API 호출/응답 매핑
  - SQLite 영속 cursor(T-21)

## 주요 변경 사항
- `LokiPullCollector`, `LokiPullClient`, `LokiPullCursorStore`(+in-memory/noop) 추가
- `IngestService.ingestPulledEvents` 추가 및 `pull:<project>:<batch>` idempotency 적용
- `LokiConnectorService`에 pull worker용 조회 메서드 추가
- `poll_interval_seconds` 런타임 반영 및 `accepted=false`/실패 시 non-commit 처리

## TDD 근거
- RED:
  - pull 관련 클래스/메서드 부재로 컴파일 실패 확인
- GREEN:
  - `./gradlew test --tests "*LokiPull*Test" --tests "*IngestServiceTest"` PASS
  - `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"` PASS
- REFACTOR:
  - idempotency/poll interval/non-commit 조건 보강 및 테스트 확대

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC4 -> `./gradlew test --tests "*Loki*Test" --tests "*Ingest*Test" --tests "*Incident*Test"` -> PASS
- Gate -> `./gradlew check && ./gradlew test && ./gradlew build` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 대기
- codex:
  - 내부 딴지 리뷰 지적(idempotency 누락/poll_interval 미반영/테스트 누락) 반영 완료

## 리스크 / 롤백
- 확인된 리스크:
  - `NoopLokiPullClient` 상태라 실제 Loki 연동은 후속 태스크에서 필요
- 롤백 계획:
  - 본 PR revert 또는 pull 스케줄링 프로퍼티 비활성화

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-17 Redaction-before-LLM + secret 로그 비노출 가드


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Loki에서 로그를 자동으로 수집하는 예약된 수집 기능 추가
  * 로그 수집 폴링 주기 설정 가능 (기본값: 30초)
  
* **개선 사항**
  * 이벤트 수집 파이프라인 최적화 및 중복 제거 강화
  
* **테스트**
  * 수집 기능 및 이벤트 처리 로직에 대한 포괄적인 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->