### PR TITLE
[WU-17] T-17 Redaction-before-LLM + secret 로그 비노출 가드

### DIFF
--- a/docs/sessions/2026-03-04-T-17.md
+++ b/docs/sessions/2026-03-04-T-17.md
@@ -102,3 +102,17 @@ Use `docs/templates/commit-message.template.md`.
   - T-18
 - Suggested first check for next session:
   - ingest 429 및 alert cooldown/quiet-hours/rate-budget 구현 시 동일 sanitizer 재사용 여부와 운영자 설정 경계 테스트를 먼저 고정할 것.
+
+## 9. PR Review Follow-up (PR #41)
+- Reason:
+  - CodeRabbit/Codex 리뷰에서 JSON literal 민감값 탐지 누락, reasonCode sanitize 보강, 테스트 분기 누락(활성 규칙 0개/가설 cause assertion) 피드백이 제기됨.
+- Changes:
+  - `SensitiveDataSanitizer`에 JSON literal(`number/boolean/null`) 패턴을 추가하고 sanitize/검증 로직에 반영.
+  - `FallbackIncidentAnalyzer`에서 `reasonCode`를 정규화(sanitize) 후 limitation 메시지에 사용.
+  - `LlmIncidentAnalyzer`의 `"LLM model"` evidence도 redaction 경로를 통과하도록 보강.
+  - `FallbackIncidentAnalyzerTest`에 hypothesis `cause` 필드 검증을 추가.
+  - `PolicyServiceTest`에 `enabled=true + rules=[]` 분기(활성 규칙 없음) 예외 테스트 추가.
+  - `SensitiveDataSanitizerTest`를 신규 추가해 JSON literal 마스킹/탐지 회귀를 고정.
+- Re-run verification:
+  - `./gradlew test --tests "*SensitiveDataSanitizerTest" --tests "*PolicyServiceTest" --tests "*LlmIncidentAnalyzerTest" --tests "*DefaultIncidentAnalyzerLoggingTest" --tests "*FallbackIncidentAnalyzerTest" --tests "*IncidentEndpointsContractTest"` => PASS
+  - `./gradlew check && ./gradlew test` => PASS

--- a/docs/sessions/2026-03-04-T-17.md
+++ b/docs/sessions/2026-03-04-T-17.md
@@ -1,0 +1,104 @@
+# Session Task Note - T-17
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #40
+- Branch: `feature/40-t17-redaction-llm-log-guard`
+- Task ID: T-17
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - LLM analyzer 직전 redaction 경로를 강제하고 policy 미구성/오작동 시 안전하게 fallback 되도록 구현한다.
+  - fallback 보고서 및 LLM 실패 로그에서 `token/password/secret/Bearer` 원문 노출을 차단한다.
+  - 보안 회귀 테스트(`Policy/Llm/Logging/Incident`)를 추가해 누출 방지를 고정한다.
+- Do not do now:
+  - SQLite 영속화/secret 암호화 저장(T-21).
+  - ingest rate-limit 및 alert storm 제어(T-18).
+  - 신규 OpenAPI 엔드포인트 추가.
+- Done means:
+  - LLM 분석 경로는 `PolicyService.redactForLlm`을 거치지 않으면 실행되지 않는다.
+  - redaction 정책 미구성/비활성/실행 실패 시 LLM 경로는 실패하고 fallback 보고서는 민감정보를 마스킹한다.
+  - LLM 실패 로그에 민감정보 원문이 남지 않는다.
+  - AC5 매핑 테스트 + 필수 게이트(`check/test`)가 green이다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction -> openapi -> architecture-guardrails -> workflow -> active spec` 순으로 재확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - In-scope인 analyzer/policy/security hardening 범위이며 Loki-only/OpenAI+Gemini 고정 결정과 충돌 없음.
+- AC-to-rule mapping to execute:
+  - AC5 -> Security/Unit -> `./gradlew test --tests "*Policy*Test" --tests "*LlmIncidentAnalyzer*Test" --tests "*Logging*Test"` -> PASS
+  - Gate -> `./gradlew check` -> PASS
+  - Gate -> `./gradlew test` -> PASS
+  - Gate(보강) -> `./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. RED: `PolicyService`, `LlmIncidentAnalyzer`, `DefaultIncidentAnalyzerLogging` 테스트를 먼저 추가해 미구현 실패를 고정한다.
+2. GREEN: redaction-before-LLM 실행 경로 및 민감정보 로그 마스킹 가드를 최소 구현한다.
+3. REFACTOR: 공통 sanitizer 도입, fallback 보고서 마스킹, 통합 계약 테스트 보강 후 회귀 검증한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/policy/PolicyServiceTest.java`
+  - `src/test/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzerTest.java`
+  - `src/test/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerLoggingTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*PolicyServiceTest" --tests "*LlmIncidentAnalyzerTest" --tests "*Logging*Test"` 실행 시
+    - `PolicyService.redactForLlm` 미존재,
+    - `LlmIncidentAnalyzer` 2-arg 생성자 미구현으로 `compileTestJava` 실패.
+- GREEN pass output summary:
+  - `./gradlew test --tests "*PolicyServiceTest" --tests "*LlmIncidentAnalyzerTest" --tests "*Logging*Test"` -> PASS
+  - 딴지 반영 후 `./gradlew test --tests "*PolicyServiceTest" --tests "*LlmIncidentAnalyzerTest" --tests "*DefaultIncidentAnalyzerLoggingTest" --tests "*FallbackIncidentAnalyzerTest" --tests "*DefaultIncidentAnalyzerChainTest" --tests "*IncidentEndpointsContractTest"` -> PASS
+- REFACTOR summary:
+  - `SensitiveDataSanitizer` 공통 유틸을 도입해 로그/보고서 마스킹 로직 중복을 제거.
+  - fallback 리포트 생성 시 summary/hypotheses/evidence/nextActions/limitations를 일괄 마스킹하도록 강화.
+  - redaction 결과 검증(`containsUnmaskedSensitiveValue`)을 추가해 규칙이 있어도 민감값이 남으면 LLM 전송을 차단.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/policy/PolicyService.java`
+  - `src/main/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzer.java`
+  - `src/main/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerChain.java`
+  - `src/main/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzer.java`
+  - `src/main/java/com/logcopilot/common/security/SensitiveDataSanitizer.java`
+  - `src/test/java/com/logcopilot/policy/PolicyServiceTest.java`
+  - `src/test/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzerTest.java`
+  - `src/test/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerLoggingTest.java`
+  - `src/test/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzerTest.java`
+  - `src/test/java/com/logcopilot/incident/IncidentEndpointsContractTest.java`
+- Why this approach:
+  - API 계약 변경 없이 analyzer 내부 경로에서 redaction 강제를 보장할 수 있다.
+  - policy 누락/오류 시에도 fallback 결과를 sanitizer로 방어해 민감정보 노출 리스크를 낮춘다.
+  - 보안 테스트를 단위+계약 레벨로 분리해 회귀 원인을 빠르게 좁힐 수 있다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*Policy*Test" --tests "*LlmIncidentAnalyzer*Test" --tests "*Logging*Test"`
+  - `./gradlew check`
+  - `./gradlew test`
+  - `./gradlew build`
+- Results:
+  - 모든 명령 PASS.
+  - 추가 회귀 묶음(`*FallbackIncidentAnalyzerTest`, `*IncidentEndpointsContractTest`)도 PASS.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Explorer sub-agent `Heisenberg`
+- Findings:
+  - 1차 리뷰에서 redaction 누락 시 fallback 원문 노출(High), 로그 sanitizer 패턴 협소(Medium), 통합 테스트 부족(Medium) 지적.
+  - 2차 리뷰에서 blocking 이슈 없음 판정, 잔여는 비-blocking(키워드 기반 탐지 한계/다른 모듈 로깅 지점)으로 정리.
+- Resolution:
+  - fallback 보고서 마스킹 + sanitizer 패턴(JSON key-value/Bearer 포함) 확장.
+  - redaction 결과에 미마스킹 민감값이 남으면 LLM 전송 차단.
+  - Incident 계약 테스트에 민감값 부재 assertion 추가.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - sanitizer는 키워드 기반(`token/password/secret/Bearer`) 탐지이므로 key-less secret 문자열 탐지는 제한적.
+  - 일부 비T-17 모듈(`LokiPullCollector`, `IncidentService`)은 여전히 예외 객체 로깅을 사용한다.
+- Next task ID:
+  - T-18
+- Suggested first check for next session:
+  - ingest 429 및 alert cooldown/quiet-hours/rate-budget 구현 시 동일 sanitizer 재사용 여부와 운영자 설정 경계 테스트를 먼저 고정할 것.

--- a/src/main/java/com/logcopilot/common/security/SensitiveDataSanitizer.java
+++ b/src/main/java/com/logcopilot/common/security/SensitiveDataSanitizer.java
@@ -1,0 +1,66 @@
+package com.logcopilot.common.security;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class SensitiveDataSanitizer {
+
+	private static final Pattern QUOTED_KEY_VALUE_PATTERN = Pattern.compile(
+		"(?i)(\"(?:token|password|secret)\"\\s*:\\s*\")([^\"]*)(\")"
+	);
+	private static final Pattern KEY_VALUE_PATTERN = Pattern.compile(
+		"(?i)(\\b(?:token|password|secret)\\b\\s*[:=]\\s*)([^\\s,;}]+)"
+	);
+	private static final Pattern BEARER_PATTERN = Pattern.compile(
+		"(?i)(\\bbearer\\s+)([^\\s,;]+)"
+	);
+
+	private SensitiveDataSanitizer() {
+	}
+
+	public static String sanitize(String text) {
+		if (text == null || text.isBlank()) {
+			return text;
+		}
+
+		String sanitized = QUOTED_KEY_VALUE_PATTERN.matcher(text)
+			.replaceAll("$1[REDACTED]$3");
+		sanitized = KEY_VALUE_PATTERN.matcher(sanitized)
+			.replaceAll("$1[REDACTED]");
+		return BEARER_PATTERN.matcher(sanitized)
+			.replaceAll("$1[REDACTED]");
+	}
+
+	public static boolean containsUnmaskedSensitiveValue(String text) {
+		if (text == null || text.isBlank()) {
+			return false;
+		}
+		return hasUnmaskedValue(QUOTED_KEY_VALUE_PATTERN.matcher(text))
+			|| hasUnmaskedValue(KEY_VALUE_PATTERN.matcher(text))
+			|| hasUnmaskedValue(BEARER_PATTERN.matcher(text));
+	}
+
+	private static boolean hasUnmaskedValue(Matcher matcher) {
+		while (matcher.find()) {
+			String value = matcher.group(2);
+			if (!isMaskedValue(value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isMaskedValue(String value) {
+		if (value == null) {
+			return true;
+		}
+		String normalized = value.trim().toLowerCase(Locale.ROOT);
+		return normalized.equals("[redacted]")
+			|| normalized.equals("[masked]")
+			|| normalized.equals("redacted")
+			|| normalized.equals("masked")
+			|| normalized.equals("<redacted>")
+			|| normalized.matches("\\*{3,}");
+	}
+}

--- a/src/main/java/com/logcopilot/common/security/SensitiveDataSanitizer.java
+++ b/src/main/java/com/logcopilot/common/security/SensitiveDataSanitizer.java
@@ -9,6 +9,9 @@ public final class SensitiveDataSanitizer {
 	private static final Pattern QUOTED_KEY_VALUE_PATTERN = Pattern.compile(
 		"(?i)(\"(?:token|password|secret)\"\\s*:\\s*\")([^\"]*)(\")"
 	);
+	private static final Pattern JSON_LITERAL_KEY_VALUE_PATTERN = Pattern.compile(
+		"(?i)(\"(?:token|password|secret)\"\\s*:\\s*)(true|false|null|-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"
+	);
 	private static final Pattern KEY_VALUE_PATTERN = Pattern.compile(
 		"(?i)(\\b(?:token|password|secret)\\b\\s*[:=]\\s*)([^\\s,;}]+)"
 	);
@@ -26,6 +29,8 @@ public final class SensitiveDataSanitizer {
 
 		String sanitized = QUOTED_KEY_VALUE_PATTERN.matcher(text)
 			.replaceAll("$1[REDACTED]$3");
+		sanitized = JSON_LITERAL_KEY_VALUE_PATTERN.matcher(sanitized)
+			.replaceAll("$1\"[REDACTED]\"");
 		sanitized = KEY_VALUE_PATTERN.matcher(sanitized)
 			.replaceAll("$1[REDACTED]");
 		return BEARER_PATTERN.matcher(sanitized)
@@ -37,6 +42,7 @@ public final class SensitiveDataSanitizer {
 			return false;
 		}
 		return hasUnmaskedValue(QUOTED_KEY_VALUE_PATTERN.matcher(text))
+			|| hasUnmaskedValue(JSON_LITERAL_KEY_VALUE_PATTERN.matcher(text))
 			|| hasUnmaskedValue(KEY_VALUE_PATTERN.matcher(text))
 			|| hasUnmaskedValue(BEARER_PATTERN.matcher(text));
 	}

--- a/src/main/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerChain.java
+++ b/src/main/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerChain.java
@@ -1,5 +1,6 @@
 package com.logcopilot.incident.analyzer;
 
+import com.logcopilot.common.security.SensitiveDataSanitizer;
 import com.logcopilot.incident.domain.AnalysisReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,11 @@ public class DefaultIncidentAnalyzerChain implements IncidentAnalyzer {
 		try {
 			return llmIncidentAnalyzer.analyze(command, ruleReport);
 		} catch (RuntimeException exception) {
-			logger.warn("LLM analyzer failed for incident: {}", command.incidentId(), exception);
+			logger.warn(
+				"LLM analyzer failed for incident: {} (error={})",
+				command.incidentId(),
+				SensitiveDataSanitizer.sanitize(exception.getMessage())
+			);
 			return fallbackIncidentAnalyzer.fromRule(ruleReport, "llm_failure");
 		}
 	}

--- a/src/main/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzer.java
+++ b/src/main/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzer.java
@@ -1,5 +1,6 @@
 package com.logcopilot.incident.analyzer;
 
+import com.logcopilot.common.security.SensitiveDataSanitizer;
 import com.logcopilot.incident.domain.AnalysisReport;
 import com.logcopilot.incident.domain.Hypothesis;
 import org.springframework.stereotype.Component;
@@ -11,24 +12,40 @@ import java.util.List;
 public class FallbackIncidentAnalyzer {
 
 	public AnalysisReport fromRule(AnalysisReport ruleReport, String reasonCode) {
-		List<Hypothesis> hypotheses = ruleReport.hypotheses() == null
-			? List.of()
-			: List.copyOf(ruleReport.hypotheses());
-		List<String> nextActions = ruleReport.nextActions() == null
-			? List.of()
-			: List.copyOf(ruleReport.nextActions());
+		List<Hypothesis> hypotheses = sanitizeHypotheses(ruleReport.hypotheses());
+		List<String> nextActions = sanitizeTextList(ruleReport.nextActions());
 
-		List<String> limitations = new ArrayList<>();
-		if (ruleReport.limitations() != null) {
-			limitations.addAll(ruleReport.limitations());
-		}
+		List<String> limitations = new ArrayList<>(sanitizeTextList(ruleReport.limitations()));
 		limitations.add("LLM analysis unavailable; fallback report generated (" + reasonCode + ")");
 
 		return new AnalysisReport(
-			ruleReport.summary(),
+			SensitiveDataSanitizer.sanitize(ruleReport.summary()),
 			hypotheses,
 			nextActions,
 			limitations
 		);
+	}
+
+	private List<Hypothesis> sanitizeHypotheses(List<Hypothesis> hypotheses) {
+		if (hypotheses == null) {
+			return List.of();
+		}
+
+		return hypotheses.stream()
+			.map(hypothesis -> new Hypothesis(
+				SensitiveDataSanitizer.sanitize(hypothesis.cause()),
+				hypothesis.confidence(),
+				sanitizeTextList(hypothesis.evidence())
+			))
+			.toList();
+	}
+
+	private List<String> sanitizeTextList(List<String> values) {
+		if (values == null) {
+			return List.of();
+		}
+		return values.stream()
+			.map(SensitiveDataSanitizer::sanitize)
+			.toList();
 	}
 }

--- a/src/main/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzer.java
+++ b/src/main/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzer.java
@@ -16,7 +16,8 @@ public class FallbackIncidentAnalyzer {
 		List<String> nextActions = sanitizeTextList(ruleReport.nextActions());
 
 		List<String> limitations = new ArrayList<>(sanitizeTextList(ruleReport.limitations()));
-		limitations.add("LLM analysis unavailable; fallback report generated (" + reasonCode + ")");
+		String sanitizedReasonCode = sanitizeReasonCode(reasonCode);
+		limitations.add("LLM analysis unavailable; fallback report generated (" + sanitizedReasonCode + ")");
 
 		return new AnalysisReport(
 			SensitiveDataSanitizer.sanitize(ruleReport.summary()),
@@ -47,5 +48,18 @@ public class FallbackIncidentAnalyzer {
 		return values.stream()
 			.map(SensitiveDataSanitizer::sanitize)
 			.toList();
+	}
+
+	private String sanitizeReasonCode(String reasonCode) {
+		if (reasonCode == null || reasonCode.isBlank()) {
+			return "unknown";
+		}
+		String sanitized = reasonCode.trim()
+			.replaceAll("[\\r\\n\\t]", "_")
+			.replaceAll("[^a-zA-Z0-9_-]", "_");
+		if (sanitized.length() > 64) {
+			return sanitized.substring(0, 64);
+		}
+		return sanitized;
 	}
 }

--- a/src/main/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzer.java
+++ b/src/main/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzer.java
@@ -4,6 +4,7 @@ import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.incident.domain.AnalysisReport;
 import com.logcopilot.incident.domain.Hypothesis;
 import com.logcopilot.llm.LlmAccountService;
+import com.logcopilot.policy.PolicyService;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -13,9 +14,11 @@ import java.util.List;
 public class LlmIncidentAnalyzer {
 
 	private final LlmAccountService llmAccountService;
+	private final PolicyService policyService;
 
-	public LlmIncidentAnalyzer(LlmAccountService llmAccountService) {
+	public LlmIncidentAnalyzer(LlmAccountService llmAccountService, PolicyService policyService) {
 		this.llmAccountService = llmAccountService;
+		this.policyService = policyService;
 	}
 
 	public boolean isAvailable(String projectId) {
@@ -45,25 +48,40 @@ public class LlmIncidentAnalyzer {
 			: hypotheses.get(0).confidence();
 		double llmConfidence = Math.min(0.95, baseConfidence + 0.18);
 
+		String redactedReason = redactForLlm(
+			command.projectId(),
+			ReanalyzeReasonNormalizer.normalize(command.reason())
+		);
+
 		List<String> evidence = new ArrayList<>();
 		evidence.add("LLM model: " + account.provider() + "/" + account.model());
-		evidence.add("Reanalysis reason: " + ReanalyzeReasonNormalizer.normalize(command.reason()));
+		evidence.add("Reanalysis reason: " + redactedReason);
 		if (!hypotheses.isEmpty() && hypotheses.get(0).evidence() != null) {
-			evidence.addAll(hypotheses.get(0).evidence());
+			hypotheses.get(0).evidence()
+				.stream()
+				.map(item -> redactForLlm(command.projectId(), item))
+				.forEach(evidence::add);
 		}
 
-		List<String> nextActions = new ArrayList<>(ruleNextActions);
-		nextActions.add("Use targeted prompts for stack trace correlation");
+		List<String> nextActions = new ArrayList<>();
+		ruleNextActions.stream()
+			.map(item -> redactForLlm(command.projectId(), item))
+			.forEach(nextActions::add);
+		nextActions.add(redactForLlm(command.projectId(), "Use targeted prompts for stack trace correlation"));
 
 		return new AnalysisReport(
 			"LLM-assisted reanalysis for incident " + command.incidentId(),
 			List.of(new Hypothesis(
-				"Likely cascading failure around service " + command.service(),
+				redactForLlm(command.projectId(), "Likely cascading failure around service " + command.service()),
 				llmConfidence,
 				evidence
 			)),
 			nextActions,
 			List.of("LLM analyzer executed with configured account")
 		);
+	}
+
+	private String redactForLlm(String projectId, String text) {
+		return policyService.redactForLlm(projectId, text);
 	}
 }

--- a/src/main/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzer.java
+++ b/src/main/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzer.java
@@ -54,7 +54,7 @@ public class LlmIncidentAnalyzer {
 		);
 
 		List<String> evidence = new ArrayList<>();
-		evidence.add("LLM model: " + account.provider() + "/" + account.model());
+		evidence.add(redactForLlm(command.projectId(), "LLM model: " + account.provider() + "/" + account.model()));
 		evidence.add("Reanalysis reason: " + redactedReason);
 		if (!hypotheses.isEmpty() && hypotheses.get(0).evidence() != null) {
 			hypotheses.get(0).evidence()

--- a/src/main/java/com/logcopilot/policy/PolicyService.java
+++ b/src/main/java/com/logcopilot/policy/PolicyService.java
@@ -1,6 +1,7 @@
 package com.logcopilot.policy;
 
 import com.logcopilot.common.error.BadRequestException;
+import com.logcopilot.common.security.SensitiveDataSanitizer;
 import com.logcopilot.project.ProjectService;
 import org.springframework.stereotype.Service;
 
@@ -57,6 +58,39 @@ public class PolicyService {
 		RedactionPolicyState updated = new RedactionPolicyState(enabled, normalizedRules, Instant.now());
 		redactionPolicyByProject.put(projectId, updated);
 		return new RedactionPolicyResult(updated.enabled(), updated.rules().size(), updated.updatedAt());
+	}
+
+	public synchronized String redactForLlm(String projectId, String rawText) {
+		requireProject(projectId);
+		RedactionPolicyState policy = redactionPolicyByProject.get(projectId);
+		if (policy == null) {
+			throw new IllegalStateException("Redaction policy is not configured");
+		}
+		if (!policy.enabled()) {
+			throw new IllegalStateException("Redaction policy is disabled");
+		}
+		if (policy.rules().isEmpty()) {
+			throw new IllegalStateException("Redaction policy has no active rules");
+		}
+		if (rawText == null || rawText.isEmpty()) {
+			return rawText;
+		}
+
+		String redacted = rawText;
+		for (RedactionRuleState rule : policy.rules()) {
+			try {
+				redacted = redacted.replaceAll(rule.pattern(), rule.replaceWith());
+			} catch (RuntimeException exception) {
+				throw new IllegalStateException(
+					"Redaction rule execution failed: " + rule.name(),
+					exception
+				);
+			}
+		}
+		if (SensitiveDataSanitizer.containsUnmaskedSensitiveValue(redacted)) {
+			throw new IllegalStateException("Redaction did not mask all sensitive values");
+		}
+		return redacted;
 	}
 
 	private void requireProject(String projectId) {

--- a/src/test/java/com/logcopilot/common/security/SensitiveDataSanitizerTest.java
+++ b/src/test/java/com/logcopilot/common/security/SensitiveDataSanitizerTest.java
@@ -1,0 +1,38 @@
+package com.logcopilot.common.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SensitiveDataSanitizerTest {
+
+	@Test
+	@DisplayName("sanitize는 JSON 숫자/불리언/null 민감값도 마스킹한다")
+	void sanitizeMasksJsonLiteralValues() {
+		String raw = "{\"token\":123,\"password\":true,\"secret\":null}";
+
+		String sanitized = SensitiveDataSanitizer.sanitize(raw);
+
+		assertThat(sanitized)
+			.contains("\"token\":\"[REDACTED]\"")
+			.contains("\"password\":\"[REDACTED]\"")
+			.contains("\"secret\":\"[REDACTED]\"")
+			.doesNotContain(":123")
+			.doesNotContain(":true")
+			.doesNotContain(":null");
+	}
+
+	@Test
+	@DisplayName("containsUnmaskedSensitiveValue는 JSON 숫자/불리언/null 민감값을 감지한다")
+	void containsUnmaskedSensitiveValueDetectsJsonLiteralValues() {
+		assertThat(SensitiveDataSanitizer.containsUnmaskedSensitiveValue("{\"token\":123}"))
+			.isTrue();
+		assertThat(SensitiveDataSanitizer.containsUnmaskedSensitiveValue("{\"password\":false}"))
+			.isTrue();
+		assertThat(SensitiveDataSanitizer.containsUnmaskedSensitiveValue("{\"secret\":null}"))
+			.isTrue();
+		assertThat(SensitiveDataSanitizer.containsUnmaskedSensitiveValue("{\"token\":\"[REDACTED]\"}"))
+			.isFalse();
+	}
+}

--- a/src/test/java/com/logcopilot/incident/IncidentEndpointsContractTest.java
+++ b/src/test/java/com/logcopilot/incident/IncidentEndpointsContractTest.java
@@ -179,6 +179,7 @@ class IncidentEndpointsContractTest {
 	void reanalyzeIncidentUsesLlmReportWhenAccountExists() throws Exception {
 		String projectId = createProjectId("incident-reanalyze-llm");
 		registerOpenAiLlmAccount(projectId);
+		configureRedactionPolicy(projectId);
 		ingestEvents(projectId, List.of(
 			event("evt-1", "2026-03-03T03:00:00Z", "api", "error", "first error")
 		));
@@ -187,15 +188,22 @@ class IncidentEndpointsContractTest {
 		mockMvc.perform(post("/v1/incidents/{incident_id}/reanalyze", incidentId)
 				.header("Authorization", "Bearer incident-token")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"reason\":\"new evidence\"}"))
+				.content("{\"reason\":\"new evidence token=abc password=pw-1\"}"))
 			.andExpect(status().isAccepted());
 
-		mockMvc.perform(get("/v1/incidents/{incident_id}", incidentId)
+		MvcResult detail = mockMvc.perform(get("/v1/incidents/{incident_id}", incidentId)
 				.header("Authorization", "Bearer incident-token"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.report.summary").value(org.hamcrest.Matchers.containsString("LLM-assisted")))
 			.andExpect(jsonPath("$.data.report.limitations[*]")
-				.value(org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("LLM"))));
+				.value(org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("LLM"))))
+			.andReturn();
+
+		String detailBody = detail.getResponse().getContentAsString();
+		assertThat(detailBody)
+			.contains("[REDACTED]")
+			.doesNotContain("token=abc")
+			.doesNotContain("password=pw-1");
 	}
 
 	@Test
@@ -210,14 +218,21 @@ class IncidentEndpointsContractTest {
 		mockMvc.perform(post("/v1/incidents/{incident_id}/reanalyze", incidentId)
 				.header("Authorization", "Bearer incident-token")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"reason\":\"new evidence\"}"))
+				.content("{\"reason\":\"new evidence token=abc password=pw-1\"}"))
 			.andExpect(status().isAccepted());
 
-		mockMvc.perform(get("/v1/incidents/{incident_id}", incidentId)
+		MvcResult detail = mockMvc.perform(get("/v1/incidents/{incident_id}", incidentId)
 				.header("Authorization", "Bearer incident-token"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.report.limitations[*]")
-				.value(org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("fallback report generated"))));
+				.value(org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("fallback report generated"))))
+			.andReturn();
+
+		String detailBody = detail.getResponse().getContentAsString();
+		assertThat(detailBody)
+			.contains("[REDACTED]")
+			.doesNotContain("token=abc")
+			.doesNotContain("password=pw-1");
 	}
 
 	@Test
@@ -338,6 +353,24 @@ class IncidentEndpointsContractTest {
 					}
 					"""))
 			.andExpect(status().isCreated());
+	}
+
+	private void configureRedactionPolicy(String projectId) throws Exception {
+		mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+				.put("/v1/projects/{project_id}/policies/redaction", projectId)
+				.header("Authorization", "Bearer policy-token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "enabled": true,
+					  "rules": [
+					    {"name":"token","pattern":"token=[^\\\\s]+","replace_with":"token=[REDACTED]"},
+					    {"name":"password","pattern":"password=[^\\\\s]+","replace_with":"password=[REDACTED]"},
+					    {"name":"secret","pattern":"secret=[^\\\\s]+","replace_with":"secret=[REDACTED]"}
+					  ]
+					}
+					"""))
+			.andExpect(status().isOk());
 	}
 
 	private String ingestEventsRequestBody(

--- a/src/test/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerLoggingTest.java
+++ b/src/test/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerLoggingTest.java
@@ -1,0 +1,79 @@
+package com.logcopilot.incident.analyzer;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.logcopilot.incident.domain.AnalysisReport;
+import com.logcopilot.incident.domain.Hypothesis;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultIncidentAnalyzerLoggingTest {
+
+	@Test
+	@DisplayName("Analyzer chain은 LLM 실패 로그에서 token/password/secret 원문을 남기지 않는다")
+	void analyzeMasksSensitiveValuesInFailureLogs() {
+		RuleBasedIncidentAnalyzer ruleAnalyzer = mock(RuleBasedIncidentAnalyzer.class);
+		LlmIncidentAnalyzer llmAnalyzer = mock(LlmIncidentAnalyzer.class);
+		FallbackIncidentAnalyzer fallbackAnalyzer = mock(FallbackIncidentAnalyzer.class);
+		DefaultIncidentAnalyzerChain chain = new DefaultIncidentAnalyzerChain(
+			ruleAnalyzer,
+			llmAnalyzer,
+			fallbackAnalyzer
+		);
+
+		IncidentReanalyzeCommand command = new IncidentReanalyzeCommand(
+			"incident-1",
+			"project-1",
+			"api",
+			"follow-up",
+			report("previous")
+		);
+		AnalysisReport ruleReport = report("rule");
+		when(ruleAnalyzer.analyze(command)).thenReturn(ruleReport);
+		when(llmAnalyzer.isAvailable("project-1")).thenReturn(true);
+		when(llmAnalyzer.analyze(command, ruleReport)).thenThrow(
+			new IllegalStateException(
+				"provider failed token=tok-1 {\"password\":\"pw-1\",\"secret\":\"sec-1\"} Bearer bearer-1"
+			)
+		);
+		when(fallbackAnalyzer.fromRule(ruleReport, "llm_failure")).thenReturn(report("fallback"));
+
+		Logger logger = (Logger) LoggerFactory.getLogger(DefaultIncidentAnalyzerChain.class);
+		ListAppender<ILoggingEvent> appender = new ListAppender<>();
+		appender.start();
+		logger.addAppender(appender);
+		try {
+			chain.analyze(command);
+		} finally {
+			logger.detachAppender(appender);
+		}
+
+		assertThat(appender.list).isNotEmpty();
+		ILoggingEvent warn = appender.list.get(0);
+		assertThat(warn.getFormattedMessage())
+			.contains("LLM analyzer failed")
+			.contains("[REDACTED]")
+			.doesNotContain("tok-1")
+			.doesNotContain("pw-1")
+			.doesNotContain("sec-1")
+			.doesNotContain("bearer-1");
+		assertThat(warn.getThrowableProxy()).isNull();
+	}
+
+	private AnalysisReport report(String summarySuffix) {
+		return new AnalysisReport(
+			"summary-" + summarySuffix,
+			List.of(new Hypothesis("cause", 0.7, List.of("evidence"))),
+			List.of("next"),
+			List.of("limitation")
+		);
+	}
+}

--- a/src/test/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzerTest.java
+++ b/src/test/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzerTest.java
@@ -30,6 +30,8 @@ class FallbackIncidentAnalyzerTest {
 		AnalysisReport result = fallbackAnalyzer.fromRule(ruleReport, "llm_failure");
 		String flattened = result.summary()
 			+ " "
+			+ result.hypotheses().get(0).cause()
+			+ " "
 			+ String.join(" ", result.hypotheses().get(0).evidence())
 			+ " "
 			+ String.join(" ", result.nextActions())

--- a/src/test/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzerTest.java
+++ b/src/test/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzerTest.java
@@ -1,0 +1,46 @@
+package com.logcopilot.incident.analyzer;
+
+import com.logcopilot.incident.domain.AnalysisReport;
+import com.logcopilot.incident.domain.Hypothesis;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FallbackIncidentAnalyzerTest {
+
+	private final FallbackIncidentAnalyzer fallbackAnalyzer = new FallbackIncidentAnalyzer();
+
+	@Test
+	@DisplayName("Fallback analyzer는 rule report의 민감정보를 마스킹해서 반환한다")
+	void fromRuleSanitizesSensitiveValues() {
+		AnalysisReport ruleReport = new AnalysisReport(
+			"summary token=abc",
+			List.of(new Hypothesis(
+				"cause password=pw-1",
+				0.62,
+				List.of("secret=sec-1", "{\"token\":\"tok-1\"}")
+			)),
+			List.of("Rotate password=pw-1"),
+			List.of("limitation token=abc")
+		);
+
+		AnalysisReport result = fallbackAnalyzer.fromRule(ruleReport, "llm_failure");
+		String flattened = result.summary()
+			+ " "
+			+ String.join(" ", result.hypotheses().get(0).evidence())
+			+ " "
+			+ String.join(" ", result.nextActions())
+			+ " "
+			+ String.join(" ", result.limitations());
+
+		assertThat(flattened)
+			.contains("[REDACTED]")
+			.doesNotContain("token=abc")
+			.doesNotContain("pw-1")
+			.doesNotContain("sec-1")
+			.doesNotContain("tok-1");
+	}
+}

--- a/src/test/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzerTest.java
+++ b/src/test/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzerTest.java
@@ -1,0 +1,124 @@
+package com.logcopilot.incident.analyzer;
+
+import com.logcopilot.incident.domain.AnalysisReport;
+import com.logcopilot.incident.domain.Hypothesis;
+import com.logcopilot.llm.LlmAccountService;
+import com.logcopilot.llm.LlmOAuthProperties;
+import com.logcopilot.policy.PolicyService;
+import com.logcopilot.project.ProjectDto;
+import com.logcopilot.project.ProjectService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LlmIncidentAnalyzerTest {
+
+	private final ProjectService projectService = new ProjectService();
+	private final PolicyService policyService = new PolicyService(projectService);
+	private final LlmAccountService llmAccountService = new LlmAccountService(
+		projectService,
+		LlmOAuthProperties.defaultProperties()
+	);
+	private final LlmIncidentAnalyzer analyzer = new LlmIncidentAnalyzer(llmAccountService, policyService);
+
+	@Test
+	@DisplayName("LlmIncidentAnalyzer는 LLM 분석 전에 rule 기반 텍스트를 redaction 적용한다")
+	void analyzeRedactsRuleTextBeforeReturningLlmReport() {
+		ProjectDto project = projectService.create("llm-redaction", "prod");
+		policyService.updateRedactionPolicy(
+			project.id(),
+			new PolicyService.RedactionPolicyCommand(
+				true,
+				List.of(
+					new PolicyService.RedactionRuleCommand("token", "token=[^\\s]+", "token=[REDACTED]"),
+					new PolicyService.RedactionRuleCommand("password", "password=[^\\s]+", "password=[REDACTED]"),
+					new PolicyService.RedactionRuleCommand("secret", "secret=[^\\s]+", "secret=[REDACTED]")
+				)
+			)
+		);
+		llmAccountService.upsertApiKey(
+			project.id(),
+			new LlmAccountService.ApiKeyUpsertCommand(
+				"openai",
+				"main",
+				"sk-openai-1",
+				"gpt-4o-mini",
+				null
+			)
+		);
+
+		AnalysisReport ruleReport = sensitiveRuleReport();
+		AnalysisReport result = analyzer.analyze(
+			new IncidentReanalyzeCommand(
+				"incident-1",
+				project.id(),
+				"api",
+				"follow-up token=abc",
+				ruleReport
+			),
+			ruleReport
+		);
+
+		String joinedEvidence = String.join(" ", result.hypotheses().get(0).evidence());
+		assertThat(joinedEvidence)
+			.contains("token=[REDACTED]")
+			.contains("password=[REDACTED]")
+			.contains("secret=[REDACTED]")
+			.doesNotContain("token=abc")
+			.doesNotContain("password=pw-1")
+			.doesNotContain("secret=sec-1");
+		assertThat(String.join(" ", result.nextActions()))
+			.doesNotContain("password=pw-1")
+			.contains("password=[REDACTED]");
+	}
+
+	@Test
+	@DisplayName("LlmIncidentAnalyzer는 redaction policy가 없으면 LLM 분석을 거부한다")
+	void analyzeRejectsWhenRedactionPolicyMissing() {
+		ProjectDto project = projectService.create("llm-redaction-missing", "prod");
+		llmAccountService.upsertApiKey(
+			project.id(),
+			new LlmAccountService.ApiKeyUpsertCommand(
+				"openai",
+				"main",
+				"sk-openai-1",
+				"gpt-4o-mini",
+				null
+			)
+		);
+
+		AnalysisReport ruleReport = sensitiveRuleReport();
+		IncidentReanalyzeCommand command = new IncidentReanalyzeCommand(
+			"incident-1",
+			project.id(),
+			"api",
+			"follow-up token=abc",
+			ruleReport
+		);
+
+		assertThatThrownBy(() -> analyzer.analyze(command, ruleReport))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Redaction policy is not configured");
+	}
+
+	private AnalysisReport sensitiveRuleReport() {
+		return new AnalysisReport(
+			"summary token=abc",
+			List.of(new Hypothesis(
+				"cause password=pw-1",
+				0.72,
+				List.of(
+					"token=abc",
+					"password=pw-1",
+					"secret=sec-1"
+				)
+			)),
+			List.of("Rotate password=pw-1"),
+			List.of("rule baseline")
+		);
+	}
+}

--- a/src/test/java/com/logcopilot/policy/PolicyServiceTest.java
+++ b/src/test/java/com/logcopilot/policy/PolicyServiceTest.java
@@ -221,6 +221,20 @@ class PolicyServiceTest {
 	}
 
 	@Test
+	@DisplayName("PolicyService는 redaction policy에 활성 규칙이 없으면 LLM 전송 텍스트 redaction을 거부한다")
+	void redactForLlmThrowsWhenNoActiveRules() {
+		ProjectDto project = projectService.create("policy-redact-llm-no-rules", "prod");
+		policyService.updateRedactionPolicy(
+			project.id(),
+			new PolicyService.RedactionPolicyCommand(true, List.of())
+		);
+
+		assertThatThrownBy(() -> policyService.redactForLlm(project.id(), "token=abc"))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Redaction policy has no active rules");
+	}
+
+	@Test
 	@DisplayName("PolicyService는 redaction 결과에 민감정보가 남아 있으면 LLM 전송 텍스트를 거부한다")
 	void redactForLlmRejectsUnmaskedSensitiveValues() {
 		ProjectDto project = projectService.create("policy-redact-llm-unmasked", "prod");

--- a/src/test/java/com/logcopilot/policy/PolicyServiceTest.java
+++ b/src/test/java/com/logcopilot/policy/PolicyServiceTest.java
@@ -167,4 +167,73 @@ class PolicyServiceTest {
 			.isInstanceOf(BadRequestException.class)
 			.hasMessage("rules[0].pattern must be at most 512 characters");
 	}
+
+	@Test
+	@DisplayName("PolicyService는 redaction policy 규칙으로 LLM 전송 텍스트를 마스킹한다")
+	void redactForLlmAppliesPolicyRules() {
+		ProjectDto project = projectService.create("policy-redact-llm", "prod");
+		policyService.updateRedactionPolicy(
+			project.id(),
+			new PolicyService.RedactionPolicyCommand(
+				true,
+				List.of(
+					new PolicyService.RedactionRuleCommand("token", "token=[^\\s]+", "token=[REDACTED]"),
+					new PolicyService.RedactionRuleCommand("password", "password=[^\\s]+", "password=[REDACTED]"),
+					new PolicyService.RedactionRuleCommand("secret", "secret=[^\\s]+", "secret=[REDACTED]")
+				)
+			)
+		);
+
+		String redacted = policyService.redactForLlm(
+			project.id(),
+			"token=abc password=pw-1 secret=sec-1"
+		);
+
+		assertThat(redacted)
+			.isEqualTo("token=[REDACTED] password=[REDACTED] secret=[REDACTED]");
+	}
+
+	@Test
+	@DisplayName("PolicyService는 redaction policy가 없으면 LLM 전송 텍스트 redaction을 거부한다")
+	void redactForLlmThrowsWhenPolicyMissing() {
+		ProjectDto project = projectService.create("policy-redact-llm-missing", "prod");
+
+		assertThatThrownBy(() -> policyService.redactForLlm(project.id(), "token=abc"))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Redaction policy is not configured");
+	}
+
+	@Test
+	@DisplayName("PolicyService는 redaction policy가 비활성화되면 LLM 전송 텍스트 redaction을 거부한다")
+	void redactForLlmThrowsWhenPolicyDisabled() {
+		ProjectDto project = projectService.create("policy-redact-llm-disabled", "prod");
+		policyService.updateRedactionPolicy(
+			project.id(),
+			new PolicyService.RedactionPolicyCommand(
+				false,
+				List.of(new PolicyService.RedactionRuleCommand("token", "token=[^\\s]+", "token=[REDACTED]"))
+			)
+		);
+
+		assertThatThrownBy(() -> policyService.redactForLlm(project.id(), "token=abc"))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Redaction policy is disabled");
+	}
+
+	@Test
+	@DisplayName("PolicyService는 redaction 결과에 민감정보가 남아 있으면 LLM 전송 텍스트를 거부한다")
+	void redactForLlmRejectsUnmaskedSensitiveValues() {
+		ProjectDto project = projectService.create("policy-redact-llm-unmasked", "prod");
+		policyService.updateRedactionPolicy(
+			project.id(),
+			new PolicyService.RedactionPolicyCommand(
+				true,
+				List.of(new PolicyService.RedactionRuleCommand("secret", "secret=[^\\s]+", "secret=[MASKED]"))
+			)
+		);
+
+		assertThatThrownBy(() -> policyService.redactForLlm(project.id(), "token=abc"))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Redaction did not mask all sensitive values");
+	}
 }


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - `PolicyService.redactForLlm`을 추가해 LLM 직전 redaction 정책을 강제했습니다.
  - redaction 미구성/비활성/실행 실패/미마스킹 감지 시 LLM 경로를 차단하고 fallback으로 전환되도록 했습니다.
  - `SensitiveDataSanitizer`를 도입해 LLM 실패 로그와 fallback 보고서에서 민감정보 원문 노출을 막았습니다.
  - Policy/Llm/Logging/Fallback/Incident 테스트를 보강해 보안 회귀를 고정했습니다.
- 왜 필요한가:
  - T-17 AC5(`redaction-before-LLM + secret 로그 비노출`) 충족 및 analyzer 보안 경계 강화를 위해 필요합니다.

## 연결 이슈
- Closes #40

## 범위 점검
- 포함:
  - Analyzer redaction 게이트, fallback 마스킹, 로그 마스킹, 보안 테스트
- 제외:
  - SQLite 영속화/secret 암호화 저장(T-21)
  - ingest rate-limit/alert storm 제어(T-18)
  - OpenAPI 신규 엔드포인트 추가

## 주요 변경 사항
- `src/main/java/com/logcopilot/policy/PolicyService.java`
  - `redactForLlm` 추가 및 미마스킹 민감값 검증
- `src/main/java/com/logcopilot/incident/analyzer/LlmIncidentAnalyzer.java`
  - 이유/evidence/nextActions/service 문구에 redaction 강제
- `src/main/java/com/logcopilot/common/security/SensitiveDataSanitizer.java`
  - `token/password/secret/Bearer` 마스킹 유틸 추가
- `src/main/java/com/logcopilot/incident/analyzer/DefaultIncidentAnalyzerChain.java`
  - 예외 메시지 마스킹 후 warn 로깅(throwable 직접 로깅 제거)
- `src/main/java/com/logcopilot/incident/analyzer/FallbackIncidentAnalyzer.java`
  - fallback 보고서 전 필드 민감정보 마스킹
- 테스트 추가/보강:
  - `LlmIncidentAnalyzerTest`, `DefaultIncidentAnalyzerLoggingTest`, `FallbackIncidentAnalyzerTest`
  - `PolicyServiceTest`, `IncidentEndpointsContractTest`

## TDD 근거
- RED:
  - `./gradlew test --tests "*PolicyServiceTest" --tests "*LlmIncidentAnalyzerTest" --tests "*Logging*Test"`
  - 초기 실행에서 `redactForLlm`/생성자 미구현으로 `compileTestJava` 실패 확인
- GREEN:
  - 동일 테스트 및 보강 테스트(`*FallbackIncidentAnalyzerTest`, `*IncidentEndpointsContractTest`) PASS
- REFACTOR:
  - 공통 sanitizer 도입 및 fallback 마스킹 로직 일원화

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC5 -> `./gradlew test --tests "*Policy*Test" --tests "*LlmIncidentAnalyzer*Test" --tests "*Logging*Test"` -> PASS
- AC5(보강) -> `./gradlew test --tests "*FallbackIncidentAnalyzerTest" --tests "*IncidentEndpointsContractTest"` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - (대기 중)
- codex:
  - explorer 딴지 리뷰 지적(원문 노출/패턴 협소/통합 검증 부족) 반영 완료

## 리스크 / 롤백
- 확인된 리스크:
  - sanitizer가 키워드 기반 탐지이므로 key-less secret 문자열 탐지는 제한적
- 롤백 계획:
  - 문제 발생 시 PR revert로 T-16 상태로 즉시 복귀 가능

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-18(ingest rate-limit + alert storm 제어)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 민감한 데이터 자동 마스킹 기능 추가
  * LLM 분석 전 리덕션 정책 적용으로 보안 강화
  * 오류 로그에서 민감한 정보 자동 제거
  * 폴백 보고서에 민감 데이터 마스킹 적용

* **테스트**
  * 리덕션 동작 및 사고 로깅 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->