### PR TITLE
[WU-19] T-19 Admin UI 기반 + 인증 경계 정립

### DIFF
--- a/docs/sessions/2026-03-04-T-19.md
+++ b/docs/sessions/2026-03-04-T-19.md
@@ -1,0 +1,102 @@
+# Session Task Note - T-19
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #45
+- Branch: `feature/45-t19-admin-ui-security-boundary`
+- Task ID: T-19
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - backend-embedded Admin UI 베이스(`/admin`)와 공통 레이아웃/내비/API 유틸/에러 처리 패턴을 구축한다.
+  - UI 인증 모델을 token bridge로 고정하고(Cookie session 미도입), CSRF/CORS/보안 헤더 정책을 보안 설정에 반영한다.
+  - UI/보안 경계 회귀 테스트를 추가하고 필수 게이트를 통과한다.
+- Do not do now:
+  - 도메인별 상세 운영 화면 구현(T-20).
+  - SQLite 영속화/secret 저장소 전환(T-21).
+  - 신규 OpenAPI 엔드포인트 추가.
+- Done means:
+  - `/admin` 진입점 및 정적 UI shell이 제공되고 공통 API client/오류 처리가 동작한다.
+  - `/v1/**` CORS 허용목록 정책, CSRF 예외 경로, 보안 헤더(CSP/Referrer/FrameOptions) 정책이 코드+테스트로 고정된다.
+  - 관련 UI/Security 테스트 및 `check/test/build`가 green이다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction -> openapi -> architecture-guardrails -> workflow -> active spec` 순으로 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - backend-embedded Admin UI 기본 골격과 운영 보안 경계 확립은 MVP in-scope.
+- AC-to-rule mapping to execute:
+  - AC7(T-19 범위) -> UI integration + security tests -> `./gradlew test --tests "*Ui*Test" --tests "*Security*Test"` -> PASS
+  - Gate -> `./gradlew check` -> PASS
+  - Gate -> `./gradlew test` -> PASS
+  - Gate -> `./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. RED: `/admin` shell/CORS preflight 정책을 검증하는 테스트를 먼저 추가해 실패를 고정한다.
+2. GREEN: Admin UI 정적 리소스 + `/admin` 진입점 + SecurityFilterChain(CORS/CSRF/헤더/public path) 변경을 최소 구현한다.
+3. REFACTOR: 딴지 피드백(토큰 저장 위험/경계 불일치/접근성 스모크 강화)을 반영하고 전체 게이트를 재검증한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java`
+  - `src/test/java/com/logcopilot/common/security/SecurityCorsPolicyIntegrationTest.java`
+- RED failure output summary:
+  - `./gradlew test --tests "*AdminUiIntegrationTest" --tests "*SecurityCorsPolicyIntegrationTest"` 실행 시
+    - `/admin` 진입점 401/리소스 미제공,
+    - CORS preflight 허용 정책 미구현으로 테스트 실패.
+- GREEN pass output summary:
+  - `./gradlew test --tests "*AdminUiIntegrationTest" --tests "*SecurityCorsPolicyIntegrationTest"` -> PASS
+  - 딴지 반영 후 `./gradlew test --tests "*AdminUiIntegrationTest" --tests "*SecurityCorsPolicyIntegrationTest" --tests "*SecurityEndpointsIntegrationTest"` -> PASS
+- REFACTOR summary:
+  - token bridge 저장소를 `sessionStorage`에서 브라우저 메모리로 전환해 토큰 노출 면적을 축소.
+  - `/favicon.ico` 공개 경로 불일치를 해소(`permitAll`)하고 401 로그 노이즈를 방지.
+  - 반응형/접근성 스모크(`media query`, `aria`, `focus-visible`) 검증을 테스트에 보강.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/java/com/logcopilot/common/security/SecurityConfiguration.java`
+  - `src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java`
+  - `src/main/java/com/logcopilot/ui/AdminUiController.java`
+  - `src/main/resources/static/admin/index.html`
+  - `src/main/resources/static/admin/styles.css`
+  - `src/main/resources/static/admin/app.js`
+  - `src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java`
+  - `src/test/java/com/logcopilot/common/security/SecurityCorsPolicyIntegrationTest.java`
+  - `src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java`
+- Why this approach:
+  - 기존 stateless bearer 체계를 유지하면서 UI 베이스를 빠르게 도입할 수 있는 최소 변경 경로다.
+  - CORS 허용목록/보안 헤더/CORS preflight를 코드로 고정해 T-20 확장 시 보안 경계를 재사용할 수 있다.
+  - OpenAPI 경로 계약 변경 없이 UI 레이어를 추가해 회귀 리스크를 낮춘다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*AdminUiIntegrationTest" --tests "*SecurityCorsPolicyIntegrationTest"`
+  - `./gradlew test --tests "*Ui*Test" --tests "*Security*Test"`
+  - `./gradlew check`
+  - `./gradlew test`
+  - `./gradlew build`
+- Results:
+  - 모든 명령 PASS.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Explorer sub-agent `Rawls`
+- Findings:
+  - Medium: token bridge의 `sessionStorage` 저장 위험.
+  - Medium: 반응형/접근성 자동화 검증 부족.
+  - Low: `/favicon.ico` 공개 경계 불일치(필터/인가 이중화).
+- Resolution:
+  - 토큰 저장 방식을 메모리 저장으로 전환.
+  - 반응형/접근성 스모크 테스트 보강.
+  - `/favicon.ico`를 `permitAll`로 맞춰 경계 일관성 확보.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - token bridge는 여전히 브라우저 JS 컨텍스트에 토큰이 존재하므로 XSS 발생 시 탈취 위험이 남아 있다(서버 세션 브릿지 전환은 후속 검토).
+  - 현재 UI 테스트는 통합 스모크 중심이며 실제 브라우저 E2E 상호작용 검증은 미도입.
+- Next task ID:
+  - T-20
+- Suggested first check for next session:
+  - T-20 시작 시 공통 API client를 기반으로 도메인별 페이지 라우팅/상태관리 구조를 먼저 확정하고, Playwright 기반 최소 E2E(모바일/데스크톱) 도입 여부를 결정할 것.

--- a/docs/sessions/2026-03-04-T-19.md
+++ b/docs/sessions/2026-03-04-T-19.md
@@ -100,3 +100,22 @@ Use `docs/templates/commit-message.template.md`.
   - T-20
 - Suggested first check for next session:
   - T-20 시작 시 공통 API client를 기반으로 도메인별 페이지 라우팅/상태관리 구조를 먼저 확정하고, Playwright 기반 최소 E2E(모바일/데스크톱) 도입 여부를 결정할 것.
+
+## 9. PR Review Follow-up (PR #46)
+- Reason:
+  - Codex/CodeRabbit 리뷰에서 컨텍스트 경로 배포 시 `/admin` 우회 실패 가능성, 공개 경로 중복 정의 드리프트, CSS 접근성/스타일 lint, JS 방어 코드 개선 피드백이 제기됨.
+- Changes:
+  - `SecurityPublicPathPolicy`를 신설해 공개 경로 정의를 단일 소스로 통합하고, 애플리케이션 상대 경로 정규화(`context-path` 제거)를 도입.
+  - `BearerAuthenticationFilter.shouldNotFilter`가 공용 정책을 사용하도록 변경해 `/logcopilot/admin` 같은 컨텍스트 경로 배포에서도 공개 경로 우회가 동작하도록 보강.
+  - `SecurityConfiguration`에서 공개 경로 permitAll과 unauthorized 메시지 경로 판별에 공용 정책을 재사용.
+  - `styles.css` 접근성/lint 보강:
+    - `Pretendard` 따옴표 제거
+    - `button`/`nav-item`의 `focus-visible` outline 추가
+  - `app.js` 안정성 보강:
+    - 필수 DOM 요소 검증(누락 시 초기화 중단 + 콘솔 에러)
+    - request body nullish 검사 일관화(`hasBody`)
+  - 회귀 테스트 추가:
+    - `BearerAuthenticationFilterTest`로 컨텍스트 경로(`server.servlet.context-path`) 시나리오의 공개/보호 경로 분기 검증.
+- Re-run verification:
+  - `./gradlew test --tests "*BearerAuthenticationFilterTest" --tests "*AdminUiIntegrationTest" --tests "*SecurityCorsPolicyIntegrationTest" --tests "*SecurityEndpointsIntegrationTest"` => PASS
+  - `./gradlew check && ./gradlew test && ./gradlew build` => PASS

--- a/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
+++ b/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
@@ -18,12 +18,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public class BearerAuthenticationFilter extends OncePerRequestFilter {
-
-	private static final Pattern OAUTH_CALLBACK_PATH = Pattern.compile("^/v1/projects/[^/]+/llm-oauth/[^/]+/callback$");
-	private static final Pattern ADMIN_UI_PATH = Pattern.compile("^/admin(?:/.*)?$");
 
 	private final BearerTokenValidator bearerTokenValidator;
 	private final AuthenticationEntryPoint authenticationEntryPoint;
@@ -38,12 +34,7 @@ public class BearerAuthenticationFilter extends OncePerRequestFilter {
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
-		String path = request.getRequestURI();
-		boolean publicEndpoint = "/healthz".equals(path)
-			|| "/readyz".equals(path)
-			|| "/favicon.ico".equals(path)
-			|| ADMIN_UI_PATH.matcher(path).matches()
-			|| OAUTH_CALLBACK_PATH.matcher(path).matches();
+		boolean publicEndpoint = SecurityPublicPathPolicy.isPublicEndpoint(request);
 		return HttpMethod.OPTIONS.matches(request.getMethod()) || publicEndpoint;
 	}
 

--- a/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
+++ b/src/main/java/com/logcopilot/common/security/BearerAuthenticationFilter.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 public class BearerAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final Pattern OAUTH_CALLBACK_PATH = Pattern.compile("^/v1/projects/[^/]+/llm-oauth/[^/]+/callback$");
+	private static final Pattern ADMIN_UI_PATH = Pattern.compile("^/admin(?:/.*)?$");
 
 	private final BearerTokenValidator bearerTokenValidator;
 	private final AuthenticationEntryPoint authenticationEntryPoint;
@@ -40,6 +41,8 @@ public class BearerAuthenticationFilter extends OncePerRequestFilter {
 		String path = request.getRequestURI();
 		boolean publicEndpoint = "/healthz".equals(path)
 			|| "/readyz".equals(path)
+			|| "/favicon.ico".equals(path)
+			|| ADMIN_UI_PATH.matcher(path).matches()
 			|| OAUTH_CALLBACK_PATH.matcher(path).matches();
 		return HttpMethod.OPTIONS.matches(request.getMethod()) || publicEndpoint;
 	}

--- a/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
+++ b/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
@@ -66,10 +66,7 @@ public class SecurityConfiguration {
 				.accessDeniedHandler(accessDeniedHandler))
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-				.requestMatchers("/healthz", "/readyz").permitAll()
-				.requestMatchers("/favicon.ico").permitAll()
-				.requestMatchers("/admin", "/admin/**").permitAll()
-				.requestMatchers("/v1/projects/*/llm-oauth/*/callback").permitAll()
+				.requestMatchers(SecurityPublicPathPolicy.PUBLIC_ENDPOINT_PATTERNS).permitAll()
 				.requestMatchers("/v1/ingest/**").hasRole("INGEST")
 				.anyRequest().hasRole("API"))
 			.addFilterBefore(bearerAuthenticationFilter, AnonymousAuthenticationFilter.class);
@@ -163,8 +160,8 @@ public class SecurityConfiguration {
 	}
 
 	private String unauthorizedMessage(HttpServletRequest request) {
-		String path = request.getRequestURI();
-		if (path != null && path.startsWith("/v1/ingest/")) {
+		String path = SecurityPublicPathPolicy.applicationPath(request);
+		if (path.startsWith("/v1/ingest/")) {
 			return "Missing or invalid ingest token";
 		}
 		return "Missing or invalid bearer token";

--- a/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
+++ b/src/main/java/com/logcopilot/common/security/SecurityConfiguration.java
@@ -5,23 +5,43 @@ import com.logcopilot.common.api.ApiErrorResponse;
 import com.logcopilot.common.auth.BearerTokenValidator;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class SecurityConfiguration {
+
+	private static final String CONTENT_SECURITY_POLICY = String.join(" ",
+		"default-src 'self';",
+		"script-src 'self';",
+		"style-src 'self';",
+		"img-src 'self' data:;",
+		"connect-src 'self';",
+		"object-src 'none';",
+		"base-uri 'self';",
+		"form-action 'self';",
+		"frame-ancestors 'none'"
+	);
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(
@@ -31,22 +51,72 @@ public class SecurityConfiguration {
 		AccessDeniedHandler accessDeniedHandler
 	) throws Exception {
 		http
-			.csrf(AbstractHttpConfigurer::disable)
+			.csrf(this::configureCsrfPolicy)
 			.cors(Customizer.withDefaults())
-			.formLogin(AbstractHttpConfigurer::disable)
-			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(form -> form.disable())
+			.httpBasic(basic -> basic.disable())
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.headers(headers -> headers
+				.contentSecurityPolicy(csp -> csp.policyDirectives(CONTENT_SECURITY_POLICY))
+				.frameOptions(frame -> frame.deny())
+				.referrerPolicy(referrer -> referrer
+					.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER)))
 			.exceptionHandling(exception -> exception
 				.authenticationEntryPoint(authenticationEntryPoint)
 				.accessDeniedHandler(accessDeniedHandler))
 			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 				.requestMatchers("/healthz", "/readyz").permitAll()
+				.requestMatchers("/favicon.ico").permitAll()
+				.requestMatchers("/admin", "/admin/**").permitAll()
 				.requestMatchers("/v1/projects/*/llm-oauth/*/callback").permitAll()
 				.requestMatchers("/v1/ingest/**").hasRole("INGEST")
 				.anyRequest().hasRole("API"))
 			.addFilterBefore(bearerAuthenticationFilter, AnonymousAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	private void configureCsrfPolicy(CsrfConfigurer<HttpSecurity> csrf) {
+		csrf.ignoringRequestMatchers(
+			"/healthz",
+			"/readyz",
+			"/admin",
+			"/admin/**",
+			"/v1/**"
+		);
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource(
+		@Value("${logcopilot.security.cors.allowed-origins:}") String allowedOriginsProperty
+	) {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(parseAllowedOrigins(allowedOriginsProperty));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of(
+			"Authorization",
+			"Content-Type",
+			"Idempotency-Key",
+			"X-CSRF-TOKEN"
+		));
+		configuration.setExposedHeaders(List.of("Retry-After", "Location"));
+		configuration.setAllowCredentials(false);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/v1/**", configuration);
+		return source;
+	}
+
+	private List<String> parseAllowedOrigins(String allowedOriginsProperty) {
+		if (allowedOriginsProperty == null || allowedOriginsProperty.isBlank()) {
+			return List.of();
+		}
+		return Arrays.stream(allowedOriginsProperty.split(","))
+			.map(String::trim)
+			.filter(value -> !value.isEmpty())
+			.toList();
 	}
 
 	@Bean

--- a/src/main/java/com/logcopilot/common/security/SecurityPublicPathPolicy.java
+++ b/src/main/java/com/logcopilot/common/security/SecurityPublicPathPolicy.java
@@ -1,0 +1,42 @@
+package com.logcopilot.common.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.AntPathMatcher;
+
+import java.util.Arrays;
+
+public final class SecurityPublicPathPolicy {
+
+	public static final String[] PUBLIC_ENDPOINT_PATTERNS = {
+		"/healthz",
+		"/readyz",
+		"/favicon.ico",
+		"/admin",
+		"/admin/**",
+		"/v1/projects/*/llm-oauth/*/callback"
+	};
+
+	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+	private SecurityPublicPathPolicy() {
+	}
+
+	public static boolean isPublicEndpoint(HttpServletRequest request) {
+		String path = applicationPath(request);
+		return Arrays.stream(PUBLIC_ENDPOINT_PATTERNS)
+			.anyMatch(pattern -> PATH_MATCHER.match(pattern, path));
+	}
+
+	public static String applicationPath(HttpServletRequest request) {
+		String requestUri = request.getRequestURI();
+		String contextPath = request.getContextPath();
+		if (contextPath != null
+			&& !contextPath.isBlank()
+			&& requestUri != null
+			&& requestUri.startsWith(contextPath)) {
+			String normalized = requestUri.substring(contextPath.length());
+			return normalized.isEmpty() ? "/" : normalized;
+		}
+		return requestUri == null || requestUri.isBlank() ? "/" : requestUri;
+	}
+}

--- a/src/main/java/com/logcopilot/ui/AdminUiController.java
+++ b/src/main/java/com/logcopilot/ui/AdminUiController.java
@@ -1,0 +1,13 @@
+package com.logcopilot.ui;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AdminUiController {
+
+	@GetMapping({"/admin", "/admin/"})
+	public String adminEntry() {
+		return "forward:/admin/index.html";
+	}
+}

--- a/src/main/resources/static/admin/app.js
+++ b/src/main/resources/static/admin/app.js
@@ -1,0 +1,241 @@
+(function () {
+	"use strict";
+
+	const SECTION_TEXT = {
+		overview: {
+			title: "개요",
+			description: "시스템 상태와 프로젝트 목록을 빠르게 확인합니다."
+		},
+		projects: {
+			title: "프로젝트",
+			description: "프로젝트 생성/조회 화면은 T-20에서 완성됩니다."
+		},
+		connectors: {
+			title: "커넥터",
+			description: "Loki 커넥터 설정/테스트 흐름을 준비 중입니다."
+		},
+		llm: {
+			title: "LLM 계정",
+			description: "OpenAI/Gemini 계정 관리 흐름을 준비 중입니다."
+		},
+		policies: {
+			title: "정책",
+			description: "Export/Redaction 정책 화면을 준비 중입니다."
+		},
+		alerts: {
+			title: "알림",
+			description: "Slack/Email 알림 설정 흐름을 준비 중입니다."
+		},
+		incidents: {
+			title: "인시던트",
+			description: "인시던트 목록/상세/재분석 화면을 준비 중입니다."
+		},
+		audit: {
+			title: "감사 로그",
+			description: "감사 로그 조회 화면을 준비 중입니다."
+		}
+	};
+
+	const state = {
+		activeNav: "overview",
+		token: "",
+		toastTimer: null
+	};
+
+	const elements = {
+		navItems: Array.from(document.querySelectorAll("[data-nav]")),
+		tokenInput: document.getElementById("api-token-input"),
+		connectButton: document.getElementById("connect-button"),
+		clearButton: document.getElementById("clear-button"),
+		refreshButton: document.getElementById("refresh-button"),
+		sectionTitle: document.getElementById("section-title"),
+		sectionDescription: document.getElementById("section-description"),
+		authStatus: document.getElementById("auth-status"),
+		preview: document.getElementById("response-preview"),
+		toast: document.getElementById("toast")
+	};
+
+	const apiClient = createApiClient(getStoredToken);
+
+	wireEvents();
+	bootstrap();
+
+	function bootstrap() {
+		updateAuthStatus();
+		activateNav(state.activeNav);
+	}
+
+	function wireEvents() {
+		elements.navItems.forEach((item) => {
+			item.addEventListener("click", () => {
+				activateNav(item.dataset.nav || "overview");
+				loadPreview();
+			});
+		});
+
+		elements.connectButton.addEventListener("click", async () => {
+			const token = elements.tokenInput.value.trim();
+			if (!token) {
+				showToast("API 토큰을 입력해 주세요.");
+				return;
+			}
+			state.token = token;
+			updateAuthStatus();
+			await loadPreview();
+		});
+
+		elements.clearButton.addEventListener("click", () => {
+			state.token = "";
+			elements.tokenInput.value = "";
+			elements.preview.textContent = "토큰이 제거되었습니다.";
+			updateAuthStatus();
+		});
+
+		elements.refreshButton.addEventListener("click", () => loadPreview());
+	}
+
+	function activateNav(nav) {
+		state.activeNav = nav;
+		elements.navItems.forEach((item) => {
+			item.classList.toggle("active", item.dataset.nav === nav);
+		});
+		const section = SECTION_TEXT[nav] || SECTION_TEXT.overview;
+		elements.sectionTitle.textContent = section.title;
+		elements.sectionDescription.textContent = section.description;
+	}
+
+	function updateAuthStatus() {
+		if (getStoredToken()) {
+			elements.authStatus.textContent = "토큰이 메모리에 설정되었습니다. API 요청 시 Authorization 헤더를 사용합니다.";
+			elements.authStatus.style.color = "#1f5c47";
+			return;
+		}
+		elements.authStatus.textContent = "토큰이 아직 설정되지 않았습니다. 새로고침 시 입력값은 유지되지 않습니다.";
+		elements.authStatus.style.color = "#6a5a47";
+	}
+
+	async function loadPreview() {
+		const token = getStoredToken();
+		if (!token) {
+			elements.preview.textContent = "API 조회를 위해 토큰을 먼저 설정해 주세요.";
+			return;
+		}
+
+		elements.preview.textContent = "조회 중...";
+		try {
+			const data = await resolvePreviewData();
+			elements.preview.textContent = JSON.stringify(data, null, 2);
+		} catch (error) {
+			const message = error && error.message ? error.message : "알 수 없는 오류";
+			elements.preview.textContent = "요청 실패: " + message;
+			showToast(message);
+		}
+	}
+
+	async function resolvePreviewData() {
+		switch (state.activeNav) {
+			case "overview":
+				return Promise.all([apiClient.getSystemInfo(), apiClient.listProjects()])
+					.then(([systemInfo, projects]) => ({ systemInfo, projects }));
+			case "projects":
+				return apiClient.listProjects();
+			case "connectors":
+				return placeholderPayload("POST /v1/projects/{project_id}/connectors/loki");
+			case "llm":
+				return placeholderPayload("POST /v1/projects/{project_id}/llm-accounts/api-key");
+			case "policies":
+				return placeholderPayload("PUT /v1/projects/{project_id}/policies/*");
+			case "alerts":
+				return placeholderPayload("POST /v1/projects/{project_id}/alerts/*");
+			case "incidents":
+				return placeholderPayload("GET /v1/projects/{project_id}/incidents");
+			case "audit":
+				return placeholderPayload("GET /v1/projects/{project_id}/audit-logs");
+			default:
+				return placeholderPayload("Unknown section");
+		}
+	}
+
+	function placeholderPayload(endpoint) {
+		return {
+			status: "planned",
+			message: "T-20에서 상세 UI를 연결합니다.",
+			endpoint
+		};
+	}
+
+	function showToast(message) {
+		if (!elements.toast) {
+			return;
+		}
+		if (state.toastTimer) {
+			window.clearTimeout(state.toastTimer);
+		}
+		elements.toast.textContent = message;
+		elements.toast.classList.add("visible");
+		state.toastTimer = window.setTimeout(() => {
+			elements.toast.classList.remove("visible");
+			state.toastTimer = null;
+		}, 2600);
+	}
+
+	function getStoredToken() {
+		return state.token;
+	}
+
+	function createApiClient(getToken) {
+		return {
+			getSystemInfo: () => request("/v1/system/info"),
+			listProjects: () => request("/v1/projects")
+		};
+
+		async function request(path, options) {
+			const config = options || {};
+			const token = getToken();
+			const headers = {
+				"Accept": "application/json",
+				...config.headers
+			};
+			if (config.body !== undefined && config.body !== null) {
+				headers["Content-Type"] = "application/json";
+			}
+			if (token) {
+				headers.Authorization = "Bearer " + token;
+			}
+
+			const response = await fetch(path, {
+				method: config.method || "GET",
+				headers,
+				body: config.body ? JSON.stringify(config.body) : undefined
+			});
+
+			const text = await response.text();
+			const payload = parseJson(text);
+
+			if (!response.ok) {
+				throw normalizeApiError(response.status, payload);
+			}
+			return payload;
+		}
+	}
+
+	function parseJson(text) {
+		if (!text) {
+			return null;
+		}
+		try {
+			return JSON.parse(text);
+		} catch (_error) {
+			return { raw: text };
+		}
+	}
+
+	function normalizeApiError(status, payload) {
+		const errorObject = payload && payload.error ? payload.error : null;
+		const code = errorObject && errorObject.code ? errorObject.code : "http_" + status;
+		const message = errorObject && errorObject.message
+			? errorObject.message
+			: "HTTP " + status + " 요청 실패";
+		return new Error(code + ": " + message);
+	}
+})();

--- a/src/main/resources/static/admin/app.js
+++ b/src/main/resources/static/admin/app.js
@@ -55,6 +55,10 @@
 		toast: document.getElementById("toast")
 	};
 
+	if (!validateRequiredElements()) {
+		return;
+	}
+
 	const apiClient = createApiClient(getStoredToken);
 
 	wireEvents();
@@ -92,6 +96,37 @@
 		});
 
 		elements.refreshButton.addEventListener("click", () => loadPreview());
+	}
+
+	function validateRequiredElements() {
+		const missing = [];
+		if (elements.navItems.length === 0) {
+			missing.push("navItems");
+		}
+
+		const requiredKeys = [
+			"tokenInput",
+			"connectButton",
+			"clearButton",
+			"refreshButton",
+			"sectionTitle",
+			"sectionDescription",
+			"authStatus",
+			"preview",
+			"toast"
+		];
+
+		requiredKeys.forEach((key) => {
+			if (!elements[key]) {
+				missing.push(key);
+			}
+		});
+
+		if (missing.length > 0) {
+			console.error("[AdminUI] Required element missing:", missing.join(", "));
+			return false;
+		}
+		return true;
 	}
 
 	function activateNav(nav) {
@@ -189,25 +224,26 @@
 			listProjects: () => request("/v1/projects")
 		};
 
-		async function request(path, options) {
-			const config = options || {};
-			const token = getToken();
-			const headers = {
-				"Accept": "application/json",
-				...config.headers
-			};
-			if (config.body !== undefined && config.body !== null) {
-				headers["Content-Type"] = "application/json";
-			}
-			if (token) {
-				headers.Authorization = "Bearer " + token;
-			}
+			async function request(path, options) {
+				const config = options || {};
+				const token = getToken();
+				const hasBody = config.body !== undefined && config.body !== null;
+				const headers = {
+					"Accept": "application/json",
+					...config.headers
+				};
+				if (hasBody) {
+					headers["Content-Type"] = "application/json";
+				}
+				if (token) {
+					headers.Authorization = "Bearer " + token;
+				}
 
-			const response = await fetch(path, {
-				method: config.method || "GET",
-				headers,
-				body: config.body ? JSON.stringify(config.body) : undefined
-			});
+				const response = await fetch(path, {
+					method: config.method || "GET",
+					headers,
+					body: hasBody ? JSON.stringify(config.body) : undefined
+				});
 
 			const text = await response.text();
 			const payload = parseJson(text);

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="ko">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>LogCopilot Admin Console</title>
+	<link rel="stylesheet" href="/admin/styles.css">
+</head>
+<body>
+<div class="bg-layer" aria-hidden="true"></div>
+<div class="shell">
+	<header class="topbar">
+		<div class="brand">
+			<span class="badge">MVP</span>
+			<h1>LogCopilot Admin Console</h1>
+		</div>
+		<p class="subtitle">Token bridge 기반 운영 콘솔 베이스 (토큰 메모리 보관)</p>
+	</header>
+
+	<div class="content-grid">
+		<nav class="nav-panel" aria-label="main-navigation">
+			<button type="button" class="nav-item active" data-nav="overview">개요</button>
+			<button type="button" class="nav-item" data-nav="projects">프로젝트</button>
+			<button type="button" class="nav-item" data-nav="connectors">커넥터</button>
+			<button type="button" class="nav-item" data-nav="llm">LLM 계정</button>
+			<button type="button" class="nav-item" data-nav="policies">정책</button>
+			<button type="button" class="nav-item" data-nav="alerts">알림</button>
+			<button type="button" class="nav-item" data-nav="incidents">인시던트</button>
+			<button type="button" class="nav-item" data-nav="audit">감사 로그</button>
+		</nav>
+
+		<main class="main-panel" aria-live="polite">
+			<section class="card auth-card">
+				<h2>API 인증 브릿지</h2>
+				<p>`/admin` 자체는 공개 shell이고, API 호출은 Bearer 토큰을 헤더로 전달합니다. 토큰은 브라우저 메모리에만 유지됩니다.</p>
+				<div class="auth-controls">
+					<label for="api-token-input">API 토큰</label>
+					<input id="api-token-input" type="password" autocomplete="off" placeholder="api-token">
+					<div class="auth-buttons">
+						<button type="button" id="connect-button">연결 테스트</button>
+						<button type="button" id="clear-button" class="secondary">토큰 삭제</button>
+					</div>
+				</div>
+				<p id="auth-status" class="status-text" role="status">토큰이 아직 설정되지 않았습니다.</p>
+			</section>
+
+			<section class="card">
+				<h2 id="section-title">개요</h2>
+				<p id="section-description">T-20에서 도메인 화면이 이 영역으로 확장됩니다.</p>
+			</section>
+
+			<section class="card">
+				<div class="card-header">
+					<h2>API Preview</h2>
+					<button type="button" id="refresh-button" class="secondary">새로고침</button>
+				</div>
+				<pre id="response-preview" class="preview" tabindex="0">아직 조회된 데이터가 없습니다.</pre>
+			</section>
+		</main>
+	</div>
+</div>
+<div id="toast" class="toast" role="alert" aria-live="assertive"></div>
+<script src="/admin/app.js" defer></script>
+</body>
+</html>

--- a/src/main/resources/static/admin/styles.css
+++ b/src/main/resources/static/admin/styles.css
@@ -21,7 +21,7 @@ body {
 	margin: 0;
 	padding: 0;
 	min-height: 100%;
-	font-family: "IBM Plex Sans", "Pretendard", "Noto Sans KR", sans-serif;
+	font-family: "IBM Plex Sans", Pretendard, "Noto Sans KR", sans-serif;
 	color: var(--text-main);
 	background: linear-gradient(130deg, var(--bg-1), var(--bg-2));
 }
@@ -149,10 +149,14 @@ body {
 	animation-delay: 280ms;
 }
 
-.nav-item:hover,
+.nav-item:hover {
+	border-color: rgba(13, 125, 84, 0.45);
+}
+
 .nav-item:focus-visible {
 	border-color: rgba(13, 125, 84, 0.45);
-	outline: none;
+	outline: 2px solid rgba(13, 125, 84, 0.52);
+	outline-offset: 2px;
 }
 
 .nav-item.active {
@@ -223,10 +227,14 @@ button {
 	cursor: pointer;
 }
 
-button:hover,
+button:hover {
+	filter: brightness(0.95);
+}
+
 button:focus-visible {
 	filter: brightness(0.95);
-	outline: none;
+	outline: 2px solid rgba(13, 125, 84, 0.52);
+	outline-offset: 2px;
 }
 
 button.secondary {

--- a/src/main/resources/static/admin/styles.css
+++ b/src/main/resources/static/admin/styles.css
@@ -1,0 +1,325 @@
+:root {
+	--bg-1: #f6f1e8;
+	--bg-2: #e5efe9;
+	--panel: rgba(255, 255, 255, 0.8);
+	--panel-strong: #ffffff;
+	--line: rgba(18, 35, 28, 0.16);
+	--text-main: #1a2e25;
+	--text-subtle: #4f655b;
+	--accent: #0d7d54;
+	--accent-strong: #0b5f3f;
+	--danger: #ae2f2f;
+	--shadow: 0 22px 50px rgba(22, 48, 38, 0.13);
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	margin: 0;
+	padding: 0;
+	min-height: 100%;
+	font-family: "IBM Plex Sans", "Pretendard", "Noto Sans KR", sans-serif;
+	color: var(--text-main);
+	background: linear-gradient(130deg, var(--bg-1), var(--bg-2));
+}
+
+.bg-layer {
+	position: fixed;
+	inset: -30%;
+	background:
+		radial-gradient(circle at 18% 20%, rgba(238, 185, 104, 0.24), transparent 45%),
+		radial-gradient(circle at 82% 12%, rgba(77, 158, 121, 0.26), transparent 40%),
+		radial-gradient(circle at 72% 80%, rgba(38, 112, 170, 0.16), transparent 42%);
+	animation: drift 24s linear infinite alternate;
+	pointer-events: none;
+}
+
+.shell {
+	position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 2.6rem 1.2rem 2rem;
+}
+
+.topbar {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: flex-end;
+	gap: 0.9rem;
+	margin-bottom: 1rem;
+}
+
+.brand {
+	display: flex;
+	align-items: center;
+	gap: 0.8rem;
+}
+
+.brand h1 {
+	margin: 0;
+	font-size: clamp(1.3rem, 2.8vw, 2rem);
+	letter-spacing: -0.02em;
+}
+
+.badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 3rem;
+	padding: 0.2rem 0.6rem;
+	border-radius: 999px;
+	background: rgba(13, 125, 84, 0.12);
+	border: 1px solid rgba(13, 125, 84, 0.35);
+	font-size: 0.75rem;
+	font-weight: 700;
+	color: var(--accent-strong);
+}
+
+.subtitle {
+	margin: 0;
+	color: var(--text-subtle);
+	font-size: 0.95rem;
+}
+
+.content-grid {
+	display: grid;
+	grid-template-columns: 220px minmax(0, 1fr);
+	gap: 1rem;
+	align-items: start;
+}
+
+.nav-panel,
+.card {
+	background: var(--panel);
+	backdrop-filter: blur(8px);
+	border-radius: 16px;
+	border: 1px solid var(--line);
+	box-shadow: var(--shadow);
+}
+
+.nav-panel {
+	padding: 0.7rem;
+	display: grid;
+	gap: 0.45rem;
+}
+
+.nav-item {
+	border: 1px solid transparent;
+	background: transparent;
+	color: var(--text-main);
+	text-align: left;
+	padding: 0.58rem 0.65rem;
+	border-radius: 10px;
+	font-weight: 600;
+	cursor: pointer;
+	transform: translateY(10px);
+	opacity: 0;
+	animation: nav-in 420ms ease forwards;
+}
+
+.nav-item:nth-child(2) {
+	animation-delay: 40ms;
+}
+
+.nav-item:nth-child(3) {
+	animation-delay: 80ms;
+}
+
+.nav-item:nth-child(4) {
+	animation-delay: 120ms;
+}
+
+.nav-item:nth-child(5) {
+	animation-delay: 160ms;
+}
+
+.nav-item:nth-child(6) {
+	animation-delay: 200ms;
+}
+
+.nav-item:nth-child(7) {
+	animation-delay: 240ms;
+}
+
+.nav-item:nth-child(8) {
+	animation-delay: 280ms;
+}
+
+.nav-item:hover,
+.nav-item:focus-visible {
+	border-color: rgba(13, 125, 84, 0.45);
+	outline: none;
+}
+
+.nav-item.active {
+	background: linear-gradient(120deg, rgba(13, 125, 84, 0.13), rgba(8, 93, 150, 0.09));
+	border-color: rgba(13, 125, 84, 0.35);
+}
+
+.main-panel {
+	display: grid;
+	gap: 1rem;
+}
+
+.card {
+	padding: 1rem 1.1rem;
+}
+
+.card h2 {
+	margin: 0 0 0.55rem;
+	font-size: 1.05rem;
+}
+
+.card p {
+	margin: 0;
+	line-height: 1.5;
+	color: var(--text-subtle);
+}
+
+.auth-controls {
+	display: grid;
+	gap: 0.45rem;
+	margin-top: 0.8rem;
+}
+
+.auth-controls label {
+	font-size: 0.85rem;
+	color: var(--text-main);
+	font-weight: 600;
+}
+
+.auth-controls input {
+	width: 100%;
+	border: 1px solid rgba(26, 46, 37, 0.18);
+	border-radius: 10px;
+	padding: 0.55rem 0.68rem;
+	font-size: 0.95rem;
+	background: var(--panel-strong);
+	color: var(--text-main);
+}
+
+.auth-controls input:focus-visible {
+	outline: 2px solid rgba(13, 125, 84, 0.4);
+	outline-offset: 1px;
+}
+
+.auth-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
+button {
+	border-radius: 10px;
+	border: 0;
+	background: var(--accent);
+	color: white;
+	font-weight: 700;
+	padding: 0.54rem 0.75rem;
+	cursor: pointer;
+}
+
+button:hover,
+button:focus-visible {
+	filter: brightness(0.95);
+	outline: none;
+}
+
+button.secondary {
+	background: #dde8e2;
+	color: #1f4033;
+}
+
+.status-text {
+	margin-top: 0.65rem;
+	font-size: 0.88rem;
+}
+
+.card-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.7rem;
+	margin-bottom: 0.55rem;
+}
+
+.preview {
+	margin: 0;
+	padding: 0.75rem;
+	border-radius: 10px;
+	background: #f2f6f4;
+	border: 1px solid rgba(28, 63, 50, 0.15);
+	min-height: 200px;
+	max-height: 420px;
+	overflow: auto;
+	font-size: 0.84rem;
+	line-height: 1.4;
+}
+
+.toast {
+	position: fixed;
+	right: 1rem;
+	bottom: 1rem;
+	background: rgba(174, 47, 47, 0.95);
+	color: white;
+	padding: 0.62rem 0.8rem;
+	border-radius: 10px;
+	opacity: 0;
+	transform: translateY(12px);
+	pointer-events: none;
+	transition: opacity 160ms ease, transform 160ms ease;
+	max-width: min(360px, calc(100vw - 2rem));
+}
+
+.toast.visible {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+@media (max-width: 900px) {
+	.content-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.nav-panel {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.nav-item {
+		text-align: center;
+	}
+}
+
+@media (max-width: 620px) {
+	.shell {
+		padding: 1.4rem 0.8rem 1.6rem;
+	}
+
+	.nav-panel {
+		grid-template-columns: 1fr;
+	}
+}
+
+@keyframes drift {
+	from {
+		transform: translate3d(-2%, -1%, 0) rotate(0deg);
+	}
+	to {
+		transform: translate3d(2%, 1%, 0) rotate(4deg);
+	}
+}
+
+@keyframes nav-in {
+	from {
+		transform: translateY(10px);
+		opacity: 0;
+	}
+	to {
+		transform: translateY(0);
+		opacity: 1;
+	}
+}

--- a/src/test/java/com/logcopilot/common/security/BearerAuthenticationFilterTest.java
+++ b/src/test/java/com/logcopilot/common/security/BearerAuthenticationFilterTest.java
@@ -1,0 +1,62 @@
+package com.logcopilot.common.security;
+
+import com.logcopilot.common.auth.BearerTokenValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class BearerAuthenticationFilterTest {
+
+	@Test
+	@DisplayName("컨텍스트 경로가 있어도 admin 경로는 인증 필터를 우회한다")
+	void shouldSkipFilterForAdminPathWithContextPath() {
+		BearerAuthenticationFilter filter = newFilter();
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/logcopilot/admin");
+		request.setContextPath("/logcopilot");
+
+		assertThat(invokeShouldNotFilter(filter, request)).isTrue();
+	}
+
+	@Test
+	@DisplayName("컨텍스트 경로가 있어도 OAuth callback 경로는 인증 필터를 우회한다")
+	void shouldSkipFilterForOauthCallbackWithContextPath() {
+		BearerAuthenticationFilter filter = newFilter();
+
+		MockHttpServletRequest request = new MockHttpServletRequest(
+			"GET",
+			"/logcopilot/v1/projects/project-1/llm-oauth/openai/callback"
+		);
+		request.setContextPath("/logcopilot");
+
+		assertThat(invokeShouldNotFilter(filter, request)).isTrue();
+	}
+
+	@Test
+	@DisplayName("컨텍스트 경로가 있어도 보호 경로는 인증 필터를 우회하지 않는다")
+	void shouldFilterProtectedPathWithContextPath() {
+		BearerAuthenticationFilter filter = newFilter();
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/logcopilot/v1/system/info");
+		request.setContextPath("/logcopilot");
+
+		assertThat(invokeShouldNotFilter(filter, request)).isFalse();
+	}
+
+	private BearerAuthenticationFilter newFilter() {
+		return new BearerAuthenticationFilter(
+			new BearerTokenValidator(),
+			mock(AuthenticationEntryPoint.class)
+		);
+	}
+
+	private boolean invokeShouldNotFilter(BearerAuthenticationFilter filter, MockHttpServletRequest request) {
+		Boolean shouldNotFilter = ReflectionTestUtils.invokeMethod(filter, "shouldNotFilter", request);
+		return Boolean.TRUE.equals(shouldNotFilter);
+	}
+}

--- a/src/test/java/com/logcopilot/common/security/SecurityCorsPolicyIntegrationTest.java
+++ b/src/test/java/com/logcopilot/common/security/SecurityCorsPolicyIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.logcopilot.common.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "logcopilot.security.cors.allowed-origins=https://admin.logcopilot.local")
+@AutoConfigureMockMvc
+class SecurityCorsPolicyIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("허용 origin 의 preflight 요청은 통과하고 CORS 헤더를 반환한다")
+	void allowedOriginPreflightReturnsCorsHeaders() throws Exception {
+		mockMvc.perform(options("/v1/system/info")
+				.header("Origin", "https://admin.logcopilot.local")
+				.header("Access-Control-Request-Method", "GET")
+				.header("Access-Control-Request-Headers", "Authorization,Content-Type"))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Access-Control-Allow-Origin", "https://admin.logcopilot.local"));
+	}
+
+	@Test
+	@DisplayName("미허용 origin 의 preflight 요청은 차단된다")
+	void disallowedOriginPreflightIsRejected() throws Exception {
+		mockMvc.perform(options("/v1/system/info")
+				.header("Origin", "https://evil.example.com")
+				.header("Access-Control-Request-Method", "GET")
+				.header("Access-Control-Request-Headers", "Authorization"))
+			.andExpect(status().isForbidden());
+	}
+}

--- a/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
+++ b/src/test/java/com/logcopilot/common/security/SecurityEndpointsIntegrationTest.java
@@ -100,4 +100,11 @@ class SecurityEndpointsIntegrationTest {
 			.andExpect(jsonPath("$.error.code").value("unauthorized"))
 			.andExpect(jsonPath("$.error.message").value("Missing or invalid bearer token"));
 	}
+
+	@Test
+	@DisplayName("favicon 요청은 인증 경계를 통과하고 자원이 없으면 404를 반환한다")
+	void faviconRequestIsNotBlockedByAuthentication() throws Exception {
+		mockMvc.perform(get("/favicon.ico"))
+			.andExpect(status().isNotFound());
+	}
 }

--- a/src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java
+++ b/src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.logcopilot.ui;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminUiIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("admin 진입점은 인증 없이 접근 가능한 UI shell을 반환한다")
+	void adminEntryPointReturnsShell() throws Exception {
+		mockMvc.perform(get("/admin"))
+			.andExpect(status().isOk())
+			.andExpect(forwardedUrl("/admin/index.html"));
+
+		mockMvc.perform(get("/admin/index.html"))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("LogCopilot Admin Console")))
+			.andExpect(content().string(containsString("data-nav=\"projects\"")))
+			.andExpect(content().string(containsString("name=\"viewport\"")));
+	}
+
+	@Test
+	@DisplayName("admin shell 응답은 기본 보안 헤더를 포함한다")
+	void adminShellIncludesSecurityHeaders() throws Exception {
+		mockMvc.perform(get("/admin"))
+			.andExpect(status().isOk())
+			.andExpect(header().string("X-Content-Type-Options", "nosniff"))
+			.andExpect(header().string("X-Frame-Options", "DENY"))
+			.andExpect(header().string("Referrer-Policy", "no-referrer"))
+			.andExpect(header().string("Content-Security-Policy", containsString("default-src 'self'")));
+	}
+
+	@Test
+	@DisplayName("admin 정적 리소스가 제공된다")
+	void adminStaticAssetsAreServed() throws Exception {
+		mockMvc.perform(get("/admin/app.js"))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Content-Type", containsString("javascript")));
+
+		mockMvc.perform(get("/admin/styles.css"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith("text/css"));
+	}
+
+	@Test
+	@DisplayName("admin shell 은 반응형/접근성 베이스 마크업을 포함한다")
+	void adminShellContainsResponsiveAndAccessibilityBasics() throws Exception {
+		mockMvc.perform(get("/admin/index.html"))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("aria-label=\"main-navigation\"")))
+			.andExpect(content().string(containsString("aria-live=\"polite\"")))
+			.andExpect(content().string(containsString("tabindex=\"0\"")));
+
+		mockMvc.perform(get("/admin/styles.css"))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("@media (max-width: 900px)")))
+			.andExpect(content().string(containsString("@media (max-width: 620px)")))
+			.andExpect(content().string(containsString(":focus-visible")));
+	}
+}


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - `/admin` backend-embedded UI shell(레이아웃/내비/API client/에러 처리) 추가
  - SecurityFilterChain에 UI 인증 경계(token bridge), CORS allowlist, CSRF 예외 정책, 보안 헤더(CSP/Referrer/FrameOptions) 적용
  - UI/보안 통합 테스트 및 세션 노트(T-19) 추가
- 왜 필요한가:
  - T-20 도메인 화면 구현 전에 공통 UI 기반과 인증/보안 경계를 먼저 고정해야 MVP 운영 흐름을 안정적으로 확장할 수 있기 때문

## 연결 이슈
- Closes #45

## 범위 점검
- 포함:
  - `/admin` 진입점 + 정적 리소스(`index.html`, `styles.css`, `app.js`)
  - token bridge 기반 API 호출(토큰 메모리 저장)
  - CORS preflight 허용/차단 정책, CSRF 예외 경로, public 경로 정책
  - UI/Security 테스트 및 딴지 피드백 반영
- 제외:
  - 프로젝트/커넥터/LLM/정책/알림/인시던트/audit 상세 화면 구현(T-20)
  - SQLite 영속화/secret 저장소 전환(T-21)

## 주요 변경 사항
- 변경 1
  - `AdminUiController` 추가: `/admin` -> `/admin/index.html` forward
  - `src/main/resources/static/admin/*` 추가: 공통 UI shell + 반응형 스타일 + API client
- 변경 2
  - `SecurityConfiguration` 업데이트: `OPTIONS` permitAll, `/admin/**` 및 `/favicon.ico` public, CORS allowlist, CSRF ignoring matcher, CSP/referrer/frame header
  - `BearerAuthenticationFilter` 업데이트: admin static/public path skip
- 변경 3
  - 테스트 추가/보강:
    - `AdminUiIntegrationTest`
    - `SecurityCorsPolicyIntegrationTest`
    - `SecurityEndpointsIntegrationTest` (`/favicon.ico` 경계 회귀)

## TDD 근거
- RED:
  - `./gradlew test --tests "*AdminUiIntegrationTest" --tests "*SecurityCorsPolicyIntegrationTest"` 최초 실행 실패
  - 원인: `/admin` shell/CORS preflight 정책 미구현
- GREEN:
  - UI shell/보안 설정 구현 후 동일 테스트 통과
- REFACTOR:
  - 딴지 반영으로 토큰 저장소를 `sessionStorage`에서 메모리로 전환
  - 반응형/접근성 스모크 검증 강화
  - `/favicon.ico` 경계 일관성 보강

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC7(T-19 범위) -> `./gradlew test --tests "*Ui*Test" --tests "*Security*Test"` -> PASS
- Gate -> `./gradlew check && ./gradlew test && ./gradlew build` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 대기 중
- codex:
  - 딴지 리뷰(Explorer Rawls) 지적 3건 반영 완료
    - 토큰 저장 보안 강화(메모리 저장)
    - 접근성/반응형 스모크 테스트 보강
    - `/favicon.ico` 경계 불일치 해소

## 리스크 / 롤백
- 확인된 리스크:
  - token bridge 특성상 브라우저 JS 컨텍스트 기반 토큰 사용은 XSS 발생 시 노출 가능성이 남음
- 롤백 계획:
  - 단일 커밋(`db312b5`) revert로 T-19 변경 전체 롤백 가능

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-20에서 도메인별 운영 화면(projects/connectors/llm/policies/alerts/incidents/audit) 구현
  - Playwright 기반 모바일/데스크톱 UI E2E 도입 여부 확정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 대시보드 UI 추가 (한국어 지원)
  * Bearer 토큰 기반 API 인증 기능
  * 개요, 프로젝트, 커넥터 등 8개 섹션 네비게이션
  * API 미리보기 기능
  * CORS 정책 및 보안 헤더 강화 (CSP, X-Frame-Options, Referrer-Policy)
  * favicon 요청 인증 우회

* **테스트**
  * 관리자 UI 통합 테스트 추가
  * 보안 CORS 정책 검증 테스트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->