### PR TITLE
[WU-20] T-20 Admin UI 핵심 운영 화면 구현

### DIFF
--- a/docs/sessions/2026-03-04-T-20.md
+++ b/docs/sessions/2026-03-04-T-20.md
@@ -111,3 +111,16 @@ Use `docs/templates/commit-message.template.md`.
   - T-21
 - Suggested first check for next session:
   - T-21 시작 시 in-memory 상태(프로젝트/커넥터/LLM/정책/알림/audit)를 SQLite 영속화로 전환해도 T-20 UI 액션이 동일하게 동작하는 통합 회귀를 먼저 작성할 것.
+
+## 9. PR Review Follow-up (PR #48)
+- Reason:
+  - CodeRabbit 액션 코멘트 4건(프로젝트 전환 캐시 초기화, redaction 규칙 파서, OAuth 팝업 차단 대응, CSS deprecated 속성)이 제기됨.
+- Changes:
+  - 프로젝트 전환 시 project-scope 캐시(`llmAccounts/incidents/incidentMeta/selectedIncident/auditLogs/auditMeta`)를 비우는 `resetProjectScopedState` + `updateActiveProject` 도입.
+  - redaction rules 파서를 `first|last delimiter` 기준으로 보강해 패턴 내 `|` 사용 시 파싱 안정성 개선.
+  - OAuth start 클릭 시 동기적으로 빈 팝업을 열고, 응답 후 URL 검증(`http/https`) 뒤 `popup.location.replace(...)` 하도록 수정(실패 시 팝업 닫기).
+  - `.table-pre`의 `word-break: break-word`를 `overflow-wrap: anywhere` + `word-break: normal`로 교체.
+- Re-run verification:
+  - `node --check src/main/resources/static/admin/app.js` => PASS
+  - `./gradlew test --tests "*AdminUiIntegrationTest"` => PASS
+  - `./gradlew check && ./gradlew test && ./gradlew build` => PASS

--- a/docs/sessions/2026-03-04-T-20.md
+++ b/docs/sessions/2026-03-04-T-20.md
@@ -1,0 +1,113 @@
+# Session Task Note - T-20
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #47
+- Branch: `feature/47-t20-admin-ui-operations`
+- Task ID: T-20
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - Admin UI에서 프로젝트/커넥터/LLM/정책/알림/인시던트/audit 운영 화면을 구현한다.
+  - 인시던트 목록/상세/재분석, audit cursor/limit 조회, 실패 UX를 반영한다.
+  - UI 통합 회귀 테스트를 보강하고 필수 게이트를 통과한다.
+- Do not do now:
+  - 신규 OpenAPI 엔드포인트 추가.
+  - DB 영속화/secret 저장소 전환(T-21 범위).
+  - 인증 모델 재설계(T-19에서 확정한 token bridge 변경).
+- Done means:
+  - `/admin` 단일 화면에서 T-20 범위 도메인 작업 폼/조회/액션이 동작한다.
+  - OAuth start 버튼은 auth URL을 생성하고 브라우저 새 창으로 연다.
+  - 감사 로그 조회는 cursor/limit/action/actor 필터와 오류 피드백을 제공한다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction -> openapi -> architecture-guardrails -> workflow -> active spec` 순서 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - backend-embedded 운영 UI 완성은 MVP in-scope.
+- AC-to-rule mapping to execute:
+  - AC7(T-20 범위) -> UI integration/regression -> `./gradlew test --tests "*Ui*Test" --tests "*EndpointsContractTest"` -> PASS
+  - Gate -> `./gradlew check` -> PASS
+  - Gate -> `./gradlew test` -> PASS
+  - Gate -> `./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. RED: `AdminUiIntegrationTest`에 T-20 운영 워크스페이스/도메인 렌더러/API 경로 기대를 추가해 실패를 고정한다.
+2. GREEN: `index.html/app.js/styles.css`를 확장해 섹션별 렌더러, 폼 액션, 실패 UX, audit/incident 흐름을 구현한다.
+3. REFACTOR: 딴지 리뷰 피드백(OAuth 시작 UX, 성공 메시지 유지, state 노출 완화)을 반영하고 전체 게이트 재검증한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java`
+    - 운영 워크스페이스 골격(`active-project-id`, `section-feedback`, `section-body`) 검증
+    - T-20 렌더러/도메인 API 경로 문자열 검증
+- RED failure output summary:
+  - `./gradlew test --tests "*AdminUiIntegrationTest"` 실행 시
+    - `admin shell 은 T-20 운영 워크스페이스 골격을 포함한다` 실패
+    - `admin app script 는 T-20 운영 API 경로와 렌더러를 포함한다` 실패
+- GREEN pass output summary:
+  - `./gradlew test --tests "*AdminUiIntegrationTest"` -> PASS
+  - `./gradlew test --tests "*Ui*Test" --tests "*EndpointsContractTest"` -> PASS
+- REFACTOR summary:
+  - OAuth start 버튼 클릭 시 `window.open`으로 인증 페이지를 즉시 여는 UX 보완.
+  - OAuth `state`는 UI 출력 시 마스킹해 노출 표면 축소.
+  - 섹션 재렌더 시 성공 피드백이 즉시 info 메시지로 덮이지 않도록 hint 처리(`setSectionHint`)로 정리.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `src/main/resources/static/admin/index.html`
+    - 운영 워크스페이스 슬롯(`active-project-id`, `section-feedback`, `section-body`) 추가.
+  - `src/main/resources/static/admin/app.js`
+    - 섹션 렌더러 8종 구현:
+      - `renderProjectsSection`
+      - `renderConnectorsSection`
+      - `renderLlmSection`
+      - `renderPoliciesSection`
+      - `renderAlertsSection`
+      - `renderIncidentsSection`
+      - `renderAuditSection`
+      - `renderOverviewSection`
+    - 도메인 API client 확장:
+      - projects/connectors/llm/policies/alerts/incidents/audit 전 경로
+    - 인시던트 상세/재분석, audit 필터(cursor/limit), 섹션별 오류/토스트 UX 추가.
+    - OAuth start 새 창 오픈 + `state` 마스킹 출력 추가.
+  - `src/main/resources/static/admin/styles.css`
+    - 워크스페이스 카드/폼/테이블/피드백 배너/반응형 확장 스타일 추가.
+  - `src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java`
+    - T-20 UI 골격/렌더러/API 경로/OAuth 핸들링 문자열 회귀 테스트 보강.
+- Why this approach:
+  - 기존 T-19 보안 경계와 token bridge를 유지하면서, OpenAPI 계약 변경 없이 MVP 운영 플로우를 UI에서 직접 수행하는 최소 확장 경로다.
+
+## 5. Verification
+- Commands:
+  - `node --check src/main/resources/static/admin/app.js`
+  - `./gradlew test --tests "*AdminUiIntegrationTest"`
+  - `./gradlew test --tests "*Ui*Test" --tests "*EndpointsContractTest"`
+  - `./gradlew check && ./gradlew test && ./gradlew build`
+- Results:
+  - 모든 명령 PASS.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Explorer sub-agent `Franklin`
+- Findings:
+  - Medium: OAuth start 버튼이 URL 생성만 하고 실제 시작 UX가 부족.
+  - Low: 섹션 재렌더 시 성공 피드백이 info 메시지로 덮이는 UX 회귀.
+  - Low: OAuth start 응답의 state가 UI에 평문 노출.
+  - High(잔여): 프런트 런타임 동작 검증이 정적 문자열 기반 테스트 중심이라 완전하지 않음.
+- Resolution:
+  - OAuth start 클릭 시 `window.open(auth_url)` 적용.
+  - `setSectionHint`로 성공/오류 피드백 유지 로직 분리.
+  - OAuth state 출력 마스킹(`maskOAuthStartResult`) 적용.
+  - 잔여 테스트 공백은 T-21/T-22 전후 E2E 도입 후보로 추적.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - 현재 UI 테스트는 여전히 서버 응답 문자열/정적 리소스 중심이며 브라우저 상호작용(E2E)까지 검증하지 않는다.
+  - OAuth start는 새 창 오픈까지 지원하지만 callback 완료 UX는 백엔드 엔드포인트 중심으로 남아 있다.
+- Next task ID:
+  - T-21
+- Suggested first check for next session:
+  - T-21 시작 시 in-memory 상태(프로젝트/커넥터/LLM/정책/알림/audit)를 SQLite 영속화로 전환해도 T-20 UI 액션이 동일하게 동작하는 통합 회귀를 먼저 작성할 것.

--- a/src/main/resources/static/admin/app.js
+++ b/src/main/resources/static/admin/app.js
@@ -4,42 +4,62 @@
 	const SECTION_TEXT = {
 		overview: {
 			title: "개요",
-			description: "시스템 상태와 프로젝트 목록을 빠르게 확인합니다."
+			description: "시스템 상태와 프로젝트 컨텍스트를 확인합니다."
 		},
 		projects: {
 			title: "프로젝트",
-			description: "프로젝트 생성/조회 화면은 T-20에서 완성됩니다."
+			description: "프로젝트 생성/조회와 활성 프로젝트 선택을 수행합니다."
 		},
 		connectors: {
 			title: "커넥터",
-			description: "Loki 커넥터 설정/테스트 흐름을 준비 중입니다."
+			description: "Loki 커넥터 설정/테스트를 수행합니다."
 		},
 		llm: {
 			title: "LLM 계정",
-			description: "OpenAI/Gemini 계정 관리 흐름을 준비 중입니다."
+			description: "API Key/OAuth 시작, 계정 목록/삭제를 수행합니다."
 		},
 		policies: {
 			title: "정책",
-			description: "Export/Redaction 정책 화면을 준비 중입니다."
+			description: "Export/Redaction 정책을 업데이트합니다."
 		},
 		alerts: {
 			title: "알림",
-			description: "Slack/Email 알림 설정 흐름을 준비 중입니다."
+			description: "Slack/Email 알림 채널을 구성합니다."
 		},
 		incidents: {
 			title: "인시던트",
-			description: "인시던트 목록/상세/재분석 화면을 준비 중입니다."
+			description: "목록/상세 조회 및 재분석 요청을 처리합니다."
 		},
 		audit: {
 			title: "감사 로그",
-			description: "감사 로그 조회 화면을 준비 중입니다."
+			description: "cursor/limit 기반 감사 로그 조회와 실패 UX를 제공합니다."
 		}
 	};
 
 	const state = {
 		activeNav: "overview",
 		token: "",
-		toastTimer: null
+		toastTimer: null,
+		projects: [],
+		activeProjectId: "",
+		llmAccounts: [],
+		incidents: [],
+		incidentMeta: null,
+		incidentFilter: {
+			status: "",
+			service: "",
+			cursor: "",
+			limit: "50"
+		},
+		selectedIncident: null,
+		auditLogs: [],
+		auditMeta: null,
+		auditFilter: {
+			action: "",
+			actor: "",
+			cursor: "",
+			limit: "50"
+		}
 	};
 
 	const elements = {
@@ -50,6 +70,9 @@
 		refreshButton: document.getElementById("refresh-button"),
 		sectionTitle: document.getElementById("section-title"),
 		sectionDescription: document.getElementById("section-description"),
+		activeProjectId: document.getElementById("active-project-id"),
+		sectionFeedback: document.getElementById("section-feedback"),
+		sectionBody: document.getElementById("section-body"),
 		authStatus: document.getElementById("auth-status"),
 		preview: document.getElementById("response-preview"),
 		toast: document.getElementById("toast")
@@ -61,7 +84,7 @@
 
 	const apiClient = createApiClient(getStoredToken);
 
-	wireEvents();
+	wireGlobalEvents();
 	bootstrap();
 
 	function bootstrap() {
@@ -69,11 +92,10 @@
 		activateNav(state.activeNav);
 	}
 
-	function wireEvents() {
+	function wireGlobalEvents() {
 		elements.navItems.forEach((item) => {
 			item.addEventListener("click", () => {
 				activateNav(item.dataset.nav || "overview");
-				loadPreview();
 			});
 		});
 
@@ -85,17 +107,33 @@
 			}
 			state.token = token;
 			updateAuthStatus();
-			await loadPreview();
+			setSectionFeedback("토큰이 설정되었습니다. 운영 API를 호출할 수 있습니다.", "success");
+			await refreshCurrentSection();
 		});
 
 		elements.clearButton.addEventListener("click", () => {
 			state.token = "";
 			elements.tokenInput.value = "";
-			elements.preview.textContent = "토큰이 제거되었습니다.";
+			clearCachedData();
 			updateAuthStatus();
+			setPreview("토큰이 제거되었습니다.");
+			activateNav(state.activeNav);
 		});
 
-		elements.refreshButton.addEventListener("click", () => loadPreview());
+		elements.refreshButton.addEventListener("click", () => {
+			refreshCurrentSection();
+		});
+	}
+
+	function clearCachedData() {
+		state.projects = [];
+		state.activeProjectId = "";
+		state.llmAccounts = [];
+		state.incidents = [];
+		state.incidentMeta = null;
+		state.selectedIncident = null;
+		state.auditLogs = [];
+		state.auditMeta = null;
 	}
 
 	function validateRequiredElements() {
@@ -111,6 +149,9 @@
 			"refreshButton",
 			"sectionTitle",
 			"sectionDescription",
+			"activeProjectId",
+			"sectionFeedback",
+			"sectionBody",
 			"authStatus",
 			"preview",
 			"toast"
@@ -130,13 +171,1163 @@
 	}
 
 	function activateNav(nav) {
-		state.activeNav = nav;
+		state.activeNav = SECTION_TEXT[nav] ? nav : "overview";
 		elements.navItems.forEach((item) => {
-			item.classList.toggle("active", item.dataset.nav === nav);
+			item.classList.toggle("active", item.dataset.nav === state.activeNav);
 		});
-		const section = SECTION_TEXT[nav] || SECTION_TEXT.overview;
+
+		const section = SECTION_TEXT[state.activeNav];
 		elements.sectionTitle.textContent = section.title;
 		elements.sectionDescription.textContent = section.description;
+		setSectionFeedback(section.description, "info");
+		renderActiveProject();
+		renderActiveSection();
+	}
+
+	function renderActiveSection() {
+		switch (state.activeNav) {
+			case "overview":
+				renderOverviewSection();
+				break;
+			case "projects":
+				renderProjectsSection();
+				break;
+			case "connectors":
+				renderConnectorsSection();
+				break;
+			case "llm":
+				renderLlmSection();
+				break;
+			case "policies":
+				renderPoliciesSection();
+				break;
+			case "alerts":
+				renderAlertsSection();
+				break;
+			case "incidents":
+				renderIncidentsSection();
+				break;
+			case "audit":
+				renderAuditSection();
+				break;
+			default:
+				renderOverviewSection();
+		}
+	}
+
+	function renderOverviewSection() {
+		const hasToken = Boolean(getStoredToken());
+		setSectionBody(
+			"<div class=\"workspace-grid\">" +
+				"<article class=\"workspace-card\">" +
+					"<h3>운영 상태</h3>" +
+					"<p class=\"muted\">토큰이 설정되어야 API 작업이 가능합니다.</p>" +
+					"<p><strong>토큰 상태:</strong> " + (hasToken ? "설정됨" : "미설정") + "</p>" +
+					"<button type=\"button\" class=\"secondary\" id=\"overview-load-button\">개요 데이터 조회</button>" +
+				"</article>" +
+				"<article class=\"workspace-card\">" +
+					"<h3>프로젝트 스냅샷</h3>" +
+					renderProjectListTable(state.projects, true) +
+				"</article>" +
+			"</div>"
+		);
+
+		const loadButton = queryInSection("#overview-load-button");
+		if (loadButton) {
+			loadButton.addEventListener("click", () => {
+				refreshCurrentSection();
+			});
+		}
+
+		if (!hasToken) {
+			setSectionFeedback("API 토큰을 입력하면 시스템/프로젝트 데이터를 조회할 수 있습니다.", "info");
+			setPreview("API 조회를 위해 토큰을 먼저 설정해 주세요.");
+			return;
+		}
+		setSectionHint("새로고침 또는 '개요 데이터 조회'로 최신 상태를 확인하세요.");
+	}
+
+	function renderProjectsSection() {
+		setSectionBody(
+			"<div class=\"workspace-grid\">" +
+				"<article class=\"workspace-card\">" +
+					"<h3>프로젝트 생성</h3>" +
+					"<form id=\"create-project-form\" class=\"form-grid\">" +
+						"<label for=\"project-name-input\">이름</label>" +
+						"<input id=\"project-name-input\" type=\"text\" maxlength=\"100\" placeholder=\"payments-prod\" required>" +
+						"<label for=\"project-environment-select\">환경</label>" +
+						"<select id=\"project-environment-select\">" +
+							"<option value=\"prod\">prod</option>" +
+							"<option value=\"staging\">staging</option>" +
+							"<option value=\"dev\">dev</option>" +
+						"</select>" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">프로젝트 생성</button>" +
+							"<button type=\"button\" class=\"secondary\" id=\"refresh-projects-button\">목록 새로고침</button>" +
+						"</div>" +
+					"</form>" +
+				"</article>" +
+				"<article class=\"workspace-card\">" +
+					"<h3>프로젝트 목록</h3>" +
+					renderProjectListTable(state.projects, false) +
+				"</article>" +
+			"</div>"
+		);
+
+		const createForm = queryInSection("#create-project-form");
+		const refreshButton = queryInSection("#refresh-projects-button");
+		const selectButtons = Array.from(queryInSectionAll(".select-project-button"));
+
+		if (createForm) {
+			createForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				if (!getStoredToken()) {
+					showToast("API 토큰을 먼저 설정해 주세요.");
+					return;
+				}
+
+				const nameInput = queryInSection("#project-name-input");
+				const environmentSelect = queryInSection("#project-environment-select");
+				const name = nameInput ? nameInput.value.trim() : "";
+				const environment = environmentSelect ? environmentSelect.value : "prod";
+
+				if (!name) {
+					showToast("프로젝트 이름을 입력해 주세요.");
+					return;
+				}
+
+				try {
+					const created = await apiClient.createProject({
+						name,
+						environment
+					});
+					await refreshProjects();
+					if (created && created.data && created.data.id) {
+						state.activeProjectId = created.data.id;
+						renderActiveProject();
+					}
+					setSectionFeedback("프로젝트가 생성되었습니다.", "success");
+					setPreview(created);
+					renderProjectsSection();
+				} catch (error) {
+					handleSectionError("프로젝트 생성에 실패했습니다.", error);
+				}
+			});
+		}
+
+		if (refreshButton) {
+			refreshButton.addEventListener("click", async () => {
+				try {
+					const projects = await refreshProjects();
+					setSectionFeedback("프로젝트 목록을 갱신했습니다.", "success");
+					setPreview(projects);
+					renderProjectsSection();
+				} catch (error) {
+					handleSectionError("프로젝트 목록 조회에 실패했습니다.", error);
+				}
+			});
+		}
+
+		selectButtons.forEach((button) => {
+			button.addEventListener("click", () => {
+				const projectId = button.getAttribute("data-project-id") || "";
+				state.activeProjectId = projectId;
+				renderActiveProject();
+				setSectionFeedback("활성 프로젝트를 선택했습니다: " + projectId, "success");
+				renderProjectsSection();
+			});
+		});
+
+		setSectionHint("프로젝트를 생성하거나 기존 프로젝트를 활성화하세요.");
+	}
+
+	function renderConnectorsSection() {
+		const projectId = state.activeProjectId;
+		if (!projectId) {
+			renderProjectRequiredMessage("커넥터 설정");
+			return;
+		}
+
+		setSectionBody(
+			"<article class=\"workspace-card\">" +
+				"<h3>Loki 커넥터 설정</h3>" +
+				"<p class=\"muted\">프로젝트: <code>" + escapeHtml(projectId) + "</code></p>" +
+				"<form id=\"connector-upsert-form\" class=\"form-grid\">" +
+					"<label for=\"connector-endpoint\">Endpoint</label>" +
+					"<input id=\"connector-endpoint\" type=\"url\" placeholder=\"https://loki.internal\" required>" +
+					"<label for=\"connector-tenant\">Tenant ID (선택)</label>" +
+					"<input id=\"connector-tenant\" type=\"text\" placeholder=\"tenant-a\">" +
+					"<label for=\"connector-query\">Query</label>" +
+					"<input id=\"connector-query\" type=\"text\" placeholder=\"{service=\\\"api\\\"} |= \\\"error\\\"\" required>" +
+					"<label for=\"connector-poll\">Poll Interval (sec)</label>" +
+					"<input id=\"connector-poll\" type=\"number\" min=\"5\" max=\"300\" value=\"30\">" +
+					"<label for=\"connector-auth-type\">Auth Type</label>" +
+					"<select id=\"connector-auth-type\">" +
+						"<option value=\"none\">none</option>" +
+						"<option value=\"bearer\">bearer</option>" +
+						"<option value=\"basic\">basic</option>" +
+					"</select>" +
+					"<label for=\"connector-auth-token\">Bearer Token</label>" +
+					"<input id=\"connector-auth-token\" type=\"password\" autocomplete=\"off\">" +
+					"<label for=\"connector-auth-username\">Basic Username</label>" +
+					"<input id=\"connector-auth-username\" type=\"text\">" +
+					"<label for=\"connector-auth-password\">Basic Password</label>" +
+					"<input id=\"connector-auth-password\" type=\"password\" autocomplete=\"off\">" +
+					"<div class=\"inline-actions\">" +
+						"<button type=\"submit\">저장/갱신</button>" +
+						"<button type=\"button\" class=\"secondary\" id=\"connector-test-button\">연결 테스트</button>" +
+					"</div>" +
+				"</form>" +
+				"<pre id=\"connectors-result\" class=\"preview preview-inline\">작업 결과가 여기에 표시됩니다.</pre>" +
+			"</article>"
+		);
+
+		const authTypeSelect = queryInSection("#connector-auth-type");
+		const tokenInput = queryInSection("#connector-auth-token");
+		const usernameInput = queryInSection("#connector-auth-username");
+		const passwordInput = queryInSection("#connector-auth-password");
+		const form = queryInSection("#connector-upsert-form");
+		const testButton = queryInSection("#connector-test-button");
+		const resultBox = queryInSection("#connectors-result");
+
+		function syncConnectorAuthFields() {
+			const authType = authTypeSelect ? authTypeSelect.value : "none";
+			const useBearer = authType === "bearer";
+			const useBasic = authType === "basic";
+
+			if (tokenInput) {
+				tokenInput.disabled = !useBearer;
+				tokenInput.required = useBearer;
+			}
+			if (usernameInput) {
+				usernameInput.disabled = !useBasic;
+				usernameInput.required = useBasic;
+			}
+			if (passwordInput) {
+				passwordInput.disabled = !useBasic;
+				passwordInput.required = useBasic;
+			}
+		}
+
+		if (authTypeSelect) {
+			authTypeSelect.addEventListener("change", syncConnectorAuthFields);
+		}
+		syncConnectorAuthFields();
+
+		if (form) {
+			form.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const endpoint = valueOf("#connector-endpoint").trim();
+					const tenant = valueOf("#connector-tenant").trim();
+					const query = valueOf("#connector-query").trim();
+					const pollInterval = valueOf("#connector-poll").trim();
+					const authType = valueOf("#connector-auth-type").trim() || "none";
+
+					const auth = { type: authType };
+					if (authType === "bearer") {
+						auth.token = valueOf("#connector-auth-token").trim();
+					}
+					if (authType === "basic") {
+						auth.username = valueOf("#connector-auth-username").trim();
+						auth.password = valueOf("#connector-auth-password").trim();
+					}
+
+					const payload = {
+						endpoint,
+						tenant_id: tenant || null,
+						auth,
+						query,
+						poll_interval_seconds: pollInterval ? Number(pollInterval) : null
+					};
+
+					const response = await apiClient.upsertLokiConnector(projectId, payload);
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("Loki 커넥터 설정이 저장되었습니다.", "success");
+					setPreview(response);
+				} catch (error) {
+					handleSectionError("커넥터 설정 저장에 실패했습니다.", error);
+				}
+			});
+		}
+
+		if (testButton) {
+			testButton.addEventListener("click", async () => {
+				try {
+					requireToken();
+					const response = await apiClient.testLokiConnector(projectId);
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("커넥터 테스트가 완료되었습니다.", "success");
+					setPreview(response);
+				} catch (error) {
+					handleSectionError("커넥터 테스트에 실패했습니다.", error);
+				}
+			});
+		}
+
+		setSectionHint("커넥터 저장 후 테스트로 연결 상태를 점검하세요.");
+	}
+
+	function renderLlmSection() {
+		const projectId = state.activeProjectId;
+		if (!projectId) {
+			renderProjectRequiredMessage("LLM 계정 관리");
+			return;
+		}
+
+		setSectionBody(
+			"<div class=\"workspace-grid\">" +
+				"<article class=\"workspace-card\">" +
+					"<h3>LLM API Key 계정</h3>" +
+					"<form id=\"llm-api-key-form\" class=\"form-grid\">" +
+						"<label for=\"llm-provider\">Provider</label>" +
+						"<select id=\"llm-provider\">" +
+							"<option value=\"openai\">openai</option>" +
+							"<option value=\"gemini\">gemini</option>" +
+						"</select>" +
+						"<label for=\"llm-label\">Label (선택)</label>" +
+						"<input id=\"llm-label\" type=\"text\" maxlength=\"80\" placeholder=\"production-openai\">" +
+						"<label for=\"llm-api-key\">API Key</label>" +
+						"<input id=\"llm-api-key\" type=\"password\" autocomplete=\"off\" required>" +
+						"<label for=\"llm-model\">Model</label>" +
+						"<input id=\"llm-model\" type=\"text\" value=\"gpt-4o-mini\" required>" +
+						"<label for=\"llm-base-url\">Base URL (선택)</label>" +
+						"<input id=\"llm-base-url\" type=\"url\" placeholder=\"https://api.openai.com\">" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">API Key 저장</button>" +
+							"<button type=\"button\" class=\"secondary\" id=\"llm-refresh-button\">목록 새로고침</button>" +
+						"</div>" +
+					"</form>" +
+					"<div class=\"inline-actions\">" +
+						"<button type=\"button\" class=\"secondary oauth-start-button\" data-provider=\"openai\">OpenAI OAuth 시작</button>" +
+						"<button type=\"button\" class=\"secondary oauth-start-button\" data-provider=\"gemini\">Gemini OAuth 시작</button>" +
+					"</div>" +
+					"<pre id=\"llm-result\" class=\"preview preview-inline\">작업 결과가 여기에 표시됩니다.</pre>" +
+				"</article>" +
+				"<article class=\"workspace-card\">" +
+					"<h3>등록 계정</h3>" +
+					renderLlmAccountsTable(state.llmAccounts) +
+				"</article>" +
+			"</div>"
+		);
+
+		const form = queryInSection("#llm-api-key-form");
+		const refreshButton = queryInSection("#llm-refresh-button");
+		const oauthButtons = Array.from(queryInSectionAll(".oauth-start-button"));
+		const deleteButtons = Array.from(queryInSectionAll(".delete-llm-account"));
+		const resultBox = queryInSection("#llm-result");
+
+		if (form) {
+			form.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const payload = {
+						provider: valueOf("#llm-provider").trim(),
+						label: valueOf("#llm-label").trim() || null,
+						api_key: valueOf("#llm-api-key").trim(),
+						model: valueOf("#llm-model").trim(),
+						base_url: valueOf("#llm-base-url").trim() || null
+					};
+
+					const response = await apiClient.upsertLlmApiKey(projectId, payload);
+					await refreshLlmAccounts();
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("LLM 계정이 저장되었습니다.", "success");
+					setPreview(response);
+					renderLlmSection();
+				} catch (error) {
+					handleSectionError("LLM 계정 저장에 실패했습니다.", error);
+				}
+			});
+		}
+
+		if (refreshButton) {
+			refreshButton.addEventListener("click", async () => {
+				try {
+					const response = await refreshLlmAccounts();
+					setSectionFeedback("LLM 계정 목록을 갱신했습니다.", "success");
+					setPreview(response);
+					renderLlmSection();
+				} catch (error) {
+					handleSectionError("LLM 계정 목록 조회에 실패했습니다.", error);
+				}
+			});
+		}
+
+		oauthButtons.forEach((button) => {
+			button.addEventListener("click", async () => {
+				try {
+					requireToken();
+					const provider = button.getAttribute("data-provider") || "openai";
+					const response = await apiClient.startLlmOAuth(projectId, provider);
+					const masked = maskOAuthStartResult(response);
+					const authUrl = response && response.data ? response.data.auth_url : null;
+					if (resultBox) {
+						resultBox.textContent = formatJson(masked);
+					}
+					if (authUrl) {
+						window.open(authUrl, "_blank", "noopener,noreferrer");
+						setSectionFeedback(provider + " OAuth 인증 페이지를 새 창으로 열었습니다.", "success");
+					} else {
+						setSectionFeedback(provider + " OAuth 시작 URL이 생성되었습니다.", "success");
+					}
+					setPreview(masked);
+				} catch (error) {
+					handleSectionError("OAuth 시작 URL 생성에 실패했습니다.", error);
+				}
+			});
+		});
+
+		deleteButtons.forEach((button) => {
+			button.addEventListener("click", async () => {
+				const accountId = button.getAttribute("data-account-id") || "";
+				if (!accountId) {
+					return;
+				}
+				try {
+					requireToken();
+					await apiClient.deleteLlmAccount(projectId, accountId);
+					await refreshLlmAccounts();
+					setSectionFeedback("LLM 계정을 삭제했습니다.", "success");
+					setPreview({ deleted: accountId });
+					renderLlmSection();
+				} catch (error) {
+					handleSectionError("LLM 계정 삭제에 실패했습니다.", error);
+				}
+			});
+		});
+
+		setSectionHint("API Key/OAuth 시작 후 목록에서 계정을 관리하세요.");
+	}
+
+	function renderPoliciesSection() {
+		const projectId = state.activeProjectId;
+		if (!projectId) {
+			renderProjectRequiredMessage("정책 설정");
+			return;
+		}
+
+		setSectionBody(
+			"<div class=\"workspace-grid\">" +
+				"<article class=\"workspace-card\">" +
+					"<h3>Export 정책</h3>" +
+					"<form id=\"export-policy-form\" class=\"form-grid\">" +
+						"<label for=\"export-level\">Export Level</label>" +
+						"<select id=\"export-level\">" +
+							"<option value=\"level0_rule_only\">level0_rule_only</option>" +
+							"<option value=\"level1_byom_only\" selected>level1_byom_only</option>" +
+							"<option value=\"level2_byom_with_telemetry\">level2_byom_with_telemetry</option>" +
+						"</select>" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">Export 정책 저장</button>" +
+						"</div>" +
+					"</form>" +
+				"</article>" +
+				"<article class=\"workspace-card\">" +
+					"<h3>Redaction 정책</h3>" +
+					"<form id=\"redaction-policy-form\" class=\"form-grid\">" +
+						"<label class=\"checkbox-row\">" +
+							"<input id=\"redaction-enabled\" type=\"checkbox\" checked>" +
+							"<span>Redaction 활성화</span>" +
+						"</label>" +
+						"<label for=\"redaction-rules\">규칙 (한 줄당 name|pattern|replace_with)</label>" +
+						"<textarea id=\"redaction-rules\" rows=\"5\" placeholder=\"api_key|api[_-]?key\\\s*[:=]\\\s*[^\\\\s]+|api_key=***\"></textarea>" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">Redaction 정책 저장</button>" +
+						"</div>" +
+					"</form>" +
+					"<pre id=\"policies-result\" class=\"preview preview-inline\">작업 결과가 여기에 표시됩니다.</pre>" +
+				"</article>" +
+			"</div>"
+		);
+
+		const exportForm = queryInSection("#export-policy-form");
+		const redactionForm = queryInSection("#redaction-policy-form");
+		const resultBox = queryInSection("#policies-result");
+
+		if (exportForm) {
+			exportForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const payload = {
+						level: valueOf("#export-level")
+					};
+					const response = await apiClient.updateExportPolicy(projectId, payload);
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("Export 정책을 저장했습니다.", "success");
+					setPreview(response);
+				} catch (error) {
+					handleSectionError("Export 정책 저장에 실패했습니다.", error);
+				}
+			});
+		}
+
+		if (redactionForm) {
+			redactionForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const enabledInput = queryInSection("#redaction-enabled");
+					const rulesText = valueOf("#redaction-rules");
+					const payload = {
+						enabled: Boolean(enabledInput && enabledInput.checked),
+						rules: parseRedactionRules(rulesText)
+					};
+					const response = await apiClient.updateRedactionPolicy(projectId, payload);
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("Redaction 정책을 저장했습니다.", "success");
+					setPreview(response);
+				} catch (error) {
+					handleSectionError("Redaction 정책 저장에 실패했습니다.", error);
+				}
+			});
+		}
+
+		setSectionHint("정책 저장 시 결과가 즉시 표시됩니다.");
+	}
+
+	function renderAlertsSection() {
+		const projectId = state.activeProjectId;
+		if (!projectId) {
+			renderProjectRequiredMessage("알림 설정");
+			return;
+		}
+
+		setSectionBody(
+			"<div class=\"workspace-grid\">" +
+				"<article class=\"workspace-card\">" +
+					"<h3>Slack 알림</h3>" +
+					"<form id=\"slack-alert-form\" class=\"form-grid\">" +
+						"<label for=\"slack-webhook\">Webhook URL</label>" +
+						"<input id=\"slack-webhook\" type=\"url\" placeholder=\"https://hooks.slack.com/services/...\" required>" +
+						"<label for=\"slack-channel\">Channel</label>" +
+						"<input id=\"slack-channel\" type=\"text\" placeholder=\"#alerts\" required>" +
+						"<label for=\"slack-min-confidence\">min_confidence</label>" +
+						"<input id=\"slack-min-confidence\" type=\"number\" min=\"0\" max=\"1\" step=\"0.01\" value=\"0.7\">" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">Slack 설정 저장</button>" +
+						"</div>" +
+					"</form>" +
+				"</article>" +
+				"<article class=\"workspace-card\">" +
+					"<h3>Email 알림</h3>" +
+					"<form id=\"email-alert-form\" class=\"form-grid\">" +
+						"<label for=\"email-from\">From</label>" +
+						"<input id=\"email-from\" type=\"email\" placeholder=\"noreply@logcopilot.io\" required>" +
+						"<label for=\"email-recipients\">Recipients (comma/newline)</label>" +
+						"<textarea id=\"email-recipients\" rows=\"2\" placeholder=\"ops@logcopilot.io, sre@logcopilot.io\" required></textarea>" +
+						"<label for=\"smtp-host\">SMTP Host</label>" +
+						"<input id=\"smtp-host\" type=\"text\" placeholder=\"smtp.example.com\" required>" +
+						"<label for=\"smtp-port\">SMTP Port</label>" +
+						"<input id=\"smtp-port\" type=\"number\" min=\"1\" max=\"65535\" value=\"587\" required>" +
+						"<label for=\"smtp-username\">SMTP Username</label>" +
+						"<input id=\"smtp-username\" type=\"text\" required>" +
+						"<label for=\"smtp-password\">SMTP Password</label>" +
+						"<input id=\"smtp-password\" type=\"password\" autocomplete=\"off\" required>" +
+						"<label class=\"checkbox-row\">" +
+							"<input id=\"smtp-starttls\" type=\"checkbox\" checked>" +
+							"<span>STARTTLS 사용</span>" +
+						"</label>" +
+						"<label for=\"email-min-confidence\">min_confidence</label>" +
+						"<input id=\"email-min-confidence\" type=\"number\" min=\"0\" max=\"1\" step=\"0.01\" value=\"0.7\">" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">Email 설정 저장</button>" +
+						"</div>" +
+					"</form>" +
+					"<pre id=\"alerts-result\" class=\"preview preview-inline\">작업 결과가 여기에 표시됩니다.</pre>" +
+				"</article>" +
+			"</div>"
+		);
+
+		const slackForm = queryInSection("#slack-alert-form");
+		const emailForm = queryInSection("#email-alert-form");
+		const resultBox = queryInSection("#alerts-result");
+
+		if (slackForm) {
+			slackForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const payload = {
+						webhook_url: valueOf("#slack-webhook").trim(),
+						channel: valueOf("#slack-channel").trim(),
+						min_confidence: parseFloatSafe(valueOf("#slack-min-confidence"))
+					};
+					const response = await apiClient.configureSlack(projectId, payload);
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("Slack 알림 설정을 저장했습니다.", "success");
+					setPreview(response);
+				} catch (error) {
+					handleSectionError("Slack 알림 설정에 실패했습니다.", error);
+				}
+			});
+		}
+
+		if (emailForm) {
+			emailForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const recipients = parseRecipients(valueOf("#email-recipients"));
+					const payload = {
+						from: valueOf("#email-from").trim(),
+						recipients,
+						smtp: {
+							host: valueOf("#smtp-host").trim(),
+							port: parseIntSafe(valueOf("#smtp-port")),
+							username: valueOf("#smtp-username").trim(),
+							password: valueOf("#smtp-password").trim(),
+							starttls: isChecked("#smtp-starttls")
+						},
+						min_confidence: parseFloatSafe(valueOf("#email-min-confidence"))
+					};
+					const response = await apiClient.configureEmail(projectId, payload);
+					if (resultBox) {
+						resultBox.textContent = formatJson(response);
+					}
+					setSectionFeedback("Email 알림 설정을 저장했습니다.", "success");
+					setPreview(response);
+				} catch (error) {
+					handleSectionError("Email 알림 설정에 실패했습니다.", error);
+				}
+			});
+		}
+
+		setSectionHint("Slack/Email 설정은 즉시 API에 반영됩니다.");
+	}
+
+	function renderIncidentsSection() {
+		const projectId = state.activeProjectId;
+		if (!projectId) {
+			renderProjectRequiredMessage("인시던트 조회");
+			return;
+		}
+
+		const filter = state.incidentFilter;
+		const detail = state.selectedIncident;
+		const nextCursor = state.incidentMeta && state.incidentMeta.next_cursor
+			? state.incidentMeta.next_cursor
+			: "없음";
+
+		setSectionBody(
+			"<article class=\"workspace-card\">" +
+				"<h3>인시던트 목록</h3>" +
+				"<form id=\"incident-filter-form\" class=\"form-grid form-grid-inline\">" +
+					"<label for=\"incident-status\">status</label>" +
+					"<select id=\"incident-status\">" +
+						"<option value=\"\">(all)</option>" +
+						"<option value=\"open\"" + selected(filter.status, "open") + ">open</option>" +
+						"<option value=\"investigating\"" + selected(filter.status, "investigating") + ">investigating</option>" +
+						"<option value=\"resolved\"" + selected(filter.status, "resolved") + ">resolved</option>" +
+					"</select>" +
+					"<label for=\"incident-service\">service</label>" +
+					"<input id=\"incident-service\" type=\"text\" value=\"" + escapeHtml(filter.service) + "\" placeholder=\"api\">" +
+					"<label for=\"incident-cursor\">cursor</label>" +
+					"<input id=\"incident-cursor\" type=\"text\" value=\"" + escapeHtml(filter.cursor) + "\" placeholder=\"0\">" +
+					"<label for=\"incident-limit\">limit</label>" +
+					"<input id=\"incident-limit\" type=\"number\" min=\"1\" max=\"200\" value=\"" + escapeHtml(filter.limit) + "\">" +
+					"<div class=\"inline-actions\">" +
+						"<button type=\"submit\">목록 조회</button>" +
+					"</div>" +
+				"</form>" +
+				"<p class=\"muted\">next cursor: <code>" + escapeHtml(nextCursor) + "</code></p>" +
+				renderIncidentsTable(state.incidents) +
+			"</article>" +
+			"<article class=\"workspace-card\">" +
+				"<h3>인시던트 상세 / 재분석</h3>" +
+				(detail ?
+					"<pre class=\"preview preview-inline\" id=\"incident-detail-preview\">" + escapeHtml(formatJson(detail)) + "</pre>" +
+					"<form id=\"incident-reanalyze-form\" class=\"form-grid\">" +
+						"<label for=\"reanalyze-reason\">reason (선택)</label>" +
+						"<textarea id=\"reanalyze-reason\" rows=\"3\" maxlength=\"500\" placeholder=\"최근 장애 대응 후 재분석\"></textarea>" +
+						"<div class=\"inline-actions\">" +
+							"<button type=\"submit\">재분석 요청</button>" +
+						"</div>" +
+					"</form>"
+					: "<p class=\"empty-state\">목록에서 인시던트를 선택하면 상세와 재분석 폼이 표시됩니다.</p>") +
+			"</article>"
+		);
+
+		const filterForm = queryInSection("#incident-filter-form");
+		const detailButtons = Array.from(queryInSectionAll(".incident-detail-button"));
+		const reanalyzeForm = queryInSection("#incident-reanalyze-form");
+
+		if (filterForm) {
+			filterForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				state.incidentFilter = {
+					status: valueOf("#incident-status").trim(),
+					service: valueOf("#incident-service").trim(),
+					cursor: valueOf("#incident-cursor").trim(),
+					limit: valueOf("#incident-limit").trim() || "50"
+				};
+				try {
+					const response = await loadIncidents();
+					setSectionFeedback("인시던트 목록을 조회했습니다.", "success");
+					setPreview(response);
+					renderIncidentsSection();
+				} catch (error) {
+					handleSectionError("인시던트 목록 조회에 실패했습니다.", error);
+				}
+			});
+		}
+
+		detailButtons.forEach((button) => {
+			button.addEventListener("click", async () => {
+				const incidentId = button.getAttribute("data-incident-id") || "";
+				if (!incidentId) {
+					return;
+				}
+				try {
+					requireToken();
+					const detailResponse = await apiClient.getIncident(incidentId);
+					state.selectedIncident = detailResponse && detailResponse.data ? detailResponse.data : null;
+					setSectionFeedback("인시던트 상세를 조회했습니다.", "success");
+					setPreview(detailResponse);
+					renderIncidentsSection();
+				} catch (error) {
+					handleSectionError("인시던트 상세 조회에 실패했습니다.", error);
+				}
+			});
+		});
+
+		if (reanalyzeForm && detail && detail.id) {
+			reanalyzeForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				try {
+					requireToken();
+					const reason = valueOf("#reanalyze-reason").trim();
+					const payload = reason ? { reason } : {};
+					const response = await apiClient.reanalyzeIncident(detail.id, payload);
+					setSectionFeedback("재분석 요청이 접수되었습니다.", "success");
+					setPreview(response);
+					const refreshedDetail = await apiClient.getIncident(detail.id);
+					state.selectedIncident = refreshedDetail && refreshedDetail.data ? refreshedDetail.data : state.selectedIncident;
+					renderIncidentsSection();
+				} catch (error) {
+					handleSectionError("재분석 요청에 실패했습니다.", error);
+				}
+			});
+		}
+
+		setSectionHint("목록 조회 후 행의 '상세' 버튼으로 세부 정보/재분석을 진행하세요.");
+	}
+
+	function renderAuditSection() {
+		const projectId = state.activeProjectId;
+		if (!projectId) {
+			renderProjectRequiredMessage("감사 로그 조회");
+			return;
+		}
+
+		const filter = state.auditFilter;
+		const nextCursor = state.auditMeta && state.auditMeta.next_cursor
+			? state.auditMeta.next_cursor
+			: "없음";
+
+		setSectionBody(
+			"<article class=\"workspace-card\">" +
+				"<h3>감사 로그 조회</h3>" +
+				"<form id=\"audit-query-form\" class=\"form-grid form-grid-inline\">" +
+					"<label for=\"audit-action\">action</label>" +
+					"<input id=\"audit-action\" type=\"text\" value=\"" + escapeHtml(filter.action) + "\" placeholder=\"alert.slack.configured\">" +
+					"<label for=\"audit-actor\">actor</label>" +
+					"<input id=\"audit-actor\" type=\"text\" value=\"" + escapeHtml(filter.actor) + "\" placeholder=\"ui-admin\">" +
+					"<label for=\"audit-cursor\">cursor</label>" +
+					"<input id=\"audit-cursor\" type=\"text\" value=\"" + escapeHtml(filter.cursor) + "\" placeholder=\"0\">" +
+					"<label for=\"audit-limit\">limit</label>" +
+					"<input id=\"audit-limit\" type=\"number\" min=\"1\" max=\"200\" value=\"" + escapeHtml(filter.limit) + "\">" +
+					"<div class=\"inline-actions\">" +
+						"<button type=\"submit\">감사 로그 조회</button>" +
+					"</div>" +
+				"</form>" +
+				"<p class=\"muted\">next cursor: <code id=\"audit-next-cursor\">" + escapeHtml(nextCursor) + "</code></p>" +
+				renderAuditLogsTable(state.auditLogs) +
+			"</article>"
+		);
+
+		const queryForm = queryInSection("#audit-query-form");
+		if (queryForm) {
+			queryForm.addEventListener("submit", async (event) => {
+				event.preventDefault();
+				state.auditFilter = {
+					action: valueOf("#audit-action").trim(),
+					actor: valueOf("#audit-actor").trim(),
+					cursor: valueOf("#audit-cursor").trim(),
+					limit: valueOf("#audit-limit").trim() || "50"
+				};
+				try {
+					const response = await loadAuditLogs();
+					setSectionFeedback("감사 로그를 조회했습니다.", "success");
+					setPreview(response);
+					renderAuditSection();
+				} catch (error) {
+					handleSectionError("감사 로그 조회에 실패했습니다.", error);
+				}
+			});
+		}
+
+		setSectionHint("cursor/limit로 페이지를 이동할 수 있습니다.");
+	}
+
+	function renderProjectRequiredMessage(featureName) {
+		setSectionBody(
+			"<article class=\"workspace-card\">" +
+				"<h3>" + escapeHtml(featureName) + "</h3>" +
+				"<p class=\"empty-state\">활성 프로젝트가 없습니다. 프로젝트 화면에서 먼저 프로젝트를 선택해 주세요.</p>" +
+				"<div class=\"inline-actions\">" +
+					"<button type=\"button\" id=\"goto-projects-button\">프로젝트 화면으로 이동</button>" +
+				"</div>" +
+			"</article>"
+		);
+		const gotoProjectsButton = queryInSection("#goto-projects-button");
+		if (gotoProjectsButton) {
+			gotoProjectsButton.addEventListener("click", () => {
+				activateNav("projects");
+			});
+		}
+		setSectionFeedback("이 섹션은 프로젝트 선택이 필요합니다.", "error");
+	}
+
+	async function refreshCurrentSection() {
+		if (!getStoredToken()) {
+			setSectionFeedback("API 토큰을 먼저 설정해 주세요.", "error");
+			setPreview("API 조회를 위해 토큰을 먼저 설정해 주세요.");
+			return;
+		}
+
+		try {
+			switch (state.activeNav) {
+				case "overview": {
+					const overview = await loadOverviewData();
+					renderOverviewSection();
+					setPreview(overview);
+					break;
+				}
+				case "projects": {
+					const projects = await refreshProjects();
+					renderProjectsSection();
+					setPreview(projects);
+					break;
+				}
+				case "llm": {
+					const llmData = await refreshLlmAccounts();
+					renderLlmSection();
+					setPreview(llmData);
+					break;
+				}
+				case "incidents": {
+					const incidents = await loadIncidents();
+					renderIncidentsSection();
+					setPreview(incidents);
+					break;
+				}
+				case "audit": {
+					const audits = await loadAuditLogs();
+					renderAuditSection();
+					setPreview(audits);
+					break;
+				}
+				default:
+					setPreview({
+						status: "ok",
+						message: "현재 섹션은 폼 액션으로 데이터를 조회/저장합니다.",
+						section: state.activeNav,
+						active_project_id: state.activeProjectId || null
+					});
+			}
+			setSectionFeedback("최신 데이터를 반영했습니다.", "success");
+		} catch (error) {
+			handleSectionError("새로고침에 실패했습니다.", error);
+		}
+	}
+
+	async function loadOverviewData() {
+		requireToken();
+		const systemInfo = await apiClient.getSystemInfo();
+		const projects = await refreshProjects();
+		return {
+			systemInfo,
+			projects,
+			active_project_id: state.activeProjectId || null
+		};
+	}
+
+	async function refreshProjects() {
+		requireToken();
+		const projects = await apiClient.listProjects();
+		state.projects = projects && Array.isArray(projects.data) ? projects.data : [];
+		reconcileActiveProject();
+		renderActiveProject();
+		return projects;
+	}
+
+	function reconcileActiveProject() {
+		if (state.projects.length === 0) {
+			state.activeProjectId = "";
+			return;
+		}
+		const exists = state.projects.some((project) => project && project.id === state.activeProjectId);
+		if (!exists) {
+			state.activeProjectId = state.projects[0] && state.projects[0].id ? state.projects[0].id : "";
+		}
+	}
+
+	async function refreshLlmAccounts() {
+		requireToken();
+		const projectId = requireActiveProject();
+		const response = await apiClient.listLlmAccounts(projectId);
+		state.llmAccounts = response && Array.isArray(response.data) ? response.data : [];
+		return response;
+	}
+
+	async function loadIncidents() {
+		requireToken();
+		const projectId = requireActiveProject();
+		const filter = state.incidentFilter;
+		const query = {};
+		if (filter.status) {
+			query.status = filter.status;
+		}
+		if (filter.service) {
+			query.service = filter.service;
+		}
+		if (filter.cursor) {
+			query.cursor = filter.cursor;
+		}
+		if (filter.limit) {
+			query.limit = parseIntSafe(filter.limit);
+		}
+
+		const response = await apiClient.listIncidents(projectId, query);
+		state.incidents = response && Array.isArray(response.data) ? response.data : [];
+		state.incidentMeta = response && response.meta ? response.meta : null;
+		state.selectedIncident = null;
+		return response;
+	}
+
+	async function loadAuditLogs() {
+		requireToken();
+		const projectId = requireActiveProject();
+		const filter = state.auditFilter;
+		const query = {};
+		if (filter.action) {
+			query.action = filter.action;
+		}
+		if (filter.actor) {
+			query.actor = filter.actor;
+		}
+		if (filter.cursor) {
+			query.cursor = filter.cursor;
+		}
+		if (filter.limit) {
+			query.limit = parseIntSafe(filter.limit);
+		}
+
+		const response = await apiClient.listAuditLogs(projectId, query);
+		state.auditLogs = response && Array.isArray(response.data) ? response.data : [];
+		state.auditMeta = response && response.meta ? response.meta : null;
+		return response;
+	}
+
+	function renderProjectListTable(projects, compact) {
+		if (!projects || projects.length === 0) {
+			return "<p class=\"empty-state\">아직 프로젝트가 없습니다.</p>";
+		}
+
+		const rows = projects.map((project) => {
+			const id = safeString(project && project.id);
+			const isActive = id && id === state.activeProjectId;
+			const actionButton = compact
+				? ""
+				: "<button type=\"button\" class=\"secondary select-project-button\" data-project-id=\"" +
+					escapeHtml(id) +
+					"\">" +
+					(isActive ? "선택됨" : "활성화") +
+					"</button>";
+
+			return "<tr>" +
+				"<td><code>" + escapeHtml(id) + "</code></td>" +
+				"<td>" + escapeHtml(safeString(project && project.name)) + "</td>" +
+				"<td>" + escapeHtml(safeString(project && project.environment)) + "</td>" +
+				"<td>" + escapeHtml(formatDateTime(project && project.created_at)) + "</td>" +
+				"<td>" + (isActive ? "<span class=\"pill\">활성</span>" : actionButton) + "</td>" +
+			"</tr>";
+		}).join("");
+
+		return "<div class=\"table-wrap\"><table class=\"data-table\">" +
+			"<thead><tr><th>ID</th><th>Name</th><th>Env</th><th>Created</th><th>Action</th></tr></thead>" +
+			"<tbody>" + rows + "</tbody>" +
+		"</table></div>";
+	}
+
+	function renderLlmAccountsTable(accounts) {
+		if (!accounts || accounts.length === 0) {
+			return "<p class=\"empty-state\">등록된 LLM 계정이 없습니다.</p>";
+		}
+
+		const rows = accounts.map((account) => {
+			const id = safeString(account && account.id);
+			return "<tr>" +
+				"<td><code>" + escapeHtml(id) + "</code></td>" +
+				"<td>" + escapeHtml(safeString(account && account.provider)) + "</td>" +
+				"<td>" + escapeHtml(safeString(account && account.auth_type)) + "</td>" +
+				"<td>" + escapeHtml(safeString(account && account.model)) + "</td>" +
+				"<td>" + escapeHtml(safeString(account && account.status)) + "</td>" +
+				"<td><button type=\"button\" class=\"secondary delete-llm-account\" data-account-id=\"" +
+					escapeHtml(id) +
+					"\">삭제</button></td>" +
+			"</tr>";
+		}).join("");
+
+		return "<div class=\"table-wrap\"><table class=\"data-table\">" +
+			"<thead><tr><th>ID</th><th>Provider</th><th>Auth</th><th>Model</th><th>Status</th><th>Action</th></tr></thead>" +
+			"<tbody>" + rows + "</tbody>" +
+		"</table></div>";
+	}
+
+	function renderIncidentsTable(incidents) {
+		if (!incidents || incidents.length === 0) {
+			return "<p class=\"empty-state\">조회된 인시던트가 없습니다.</p>";
+		}
+
+		const rows = incidents.map((incident) => {
+			const id = safeString(incident && incident.id);
+			return "<tr>" +
+				"<td><code>" + escapeHtml(id) + "</code></td>" +
+				"<td>" + escapeHtml(safeString(incident && incident.status)) + "</td>" +
+				"<td>" + escapeHtml(safeString(incident && incident.service)) + "</td>" +
+				"<td>" + escapeHtml(String(incident && incident.severity_score != null ? incident.severity_score : "-")) + "</td>" +
+				"<td>" + escapeHtml(String(incident && incident.event_count != null ? incident.event_count : "-")) + "</td>" +
+				"<td><button type=\"button\" class=\"secondary incident-detail-button\" data-incident-id=\"" +
+					escapeHtml(id) +
+					"\">상세</button></td>" +
+			"</tr>";
+		}).join("");
+
+		return "<div class=\"table-wrap\"><table class=\"data-table\">" +
+			"<thead><tr><th>ID</th><th>Status</th><th>Service</th><th>Severity</th><th>Events</th><th>Action</th></tr></thead>" +
+			"<tbody>" + rows + "</tbody>" +
+		"</table></div>";
+	}
+
+	function renderAuditLogsTable(logs) {
+		if (!logs || logs.length === 0) {
+			return "<p class=\"empty-state\">조회된 감사 로그가 없습니다.</p>";
+		}
+
+		const rows = logs.map((log) => {
+			const metadata = log && log.metadata ? formatJson(log.metadata) : "{}";
+			return "<tr>" +
+				"<td><code>" + escapeHtml(safeString(log && log.id)) + "</code></td>" +
+				"<td>" + escapeHtml(safeString(log && log.actor)) + "</td>" +
+				"<td>" + escapeHtml(safeString(log && log.action)) + "</td>" +
+				"<td>" + escapeHtml(safeString(log && log.resource_type)) + "</td>" +
+				"<td>" + escapeHtml(safeString(log && log.resource_id)) + "</td>" +
+				"<td>" + escapeHtml(formatDateTime(log && log.created_at)) + "</td>" +
+				"<td><pre class=\"table-pre\">" + escapeHtml(metadata) + "</pre></td>" +
+			"</tr>";
+		}).join("");
+
+		return "<div class=\"table-wrap\"><table class=\"data-table\">" +
+			"<thead><tr><th>ID</th><th>Actor</th><th>Action</th><th>Type</th><th>Resource</th><th>Created</th><th>Metadata</th></tr></thead>" +
+			"<tbody>" + rows + "</tbody>" +
+		"</table></div>";
+	}
+
+	function parseRedactionRules(text) {
+		const lines = text
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+		if (lines.length === 0) {
+			return [];
+		}
+		return lines.map((line, index) => {
+			const tokens = line.split("|").map((token) => token.trim());
+			if (tokens.length < 3) {
+				throw new Error("redaction rules 형식 오류 (line " + (index + 1) + "): name|pattern|replace_with");
+			}
+			return {
+				name: tokens[0],
+				pattern: tokens[1],
+				replace_with: tokens.slice(2).join("|")
+			};
+		});
+	}
+
+	function parseRecipients(raw) {
+		const recipients = raw
+			.split(/[\n,]/)
+			.map((value) => value.trim())
+			.filter((value) => value.length > 0);
+		if (recipients.length === 0) {
+			throw new Error("수신 이메일을 하나 이상 입력해 주세요.");
+		}
+		return recipients;
+	}
+
+	function requireToken() {
+		if (!getStoredToken()) {
+			throw new Error("API 토큰을 먼저 설정해 주세요.");
+		}
+	}
+
+	function requireActiveProject() {
+		if (!state.activeProjectId) {
+			throw new Error("활성 프로젝트를 먼저 선택해 주세요.");
+		}
+		return state.activeProjectId;
+	}
+
+	function valueOf(selector) {
+		const target = queryInSection(selector);
+		if (!target) {
+			return "";
+		}
+		return typeof target.value === "string" ? target.value : "";
+	}
+
+	function isChecked(selector) {
+		const target = queryInSection(selector);
+		return Boolean(target && target.checked);
+	}
+
+	function queryInSection(selector) {
+		if (!elements.sectionBody) {
+			return null;
+		}
+		return elements.sectionBody.querySelector(selector);
+	}
+
+	function queryInSectionAll(selector) {
+		if (!elements.sectionBody) {
+			return [];
+		}
+		return elements.sectionBody.querySelectorAll(selector);
+	}
+
+	function selected(value, expected) {
+		return value === expected ? " selected" : "";
+	}
+
+	function renderActiveProject() {
+		elements.activeProjectId.textContent = state.activeProjectId || "없음";
 	}
 
 	function updateAuthStatus() {
@@ -149,54 +1340,58 @@
 		elements.authStatus.style.color = "#6a5a47";
 	}
 
-	async function loadPreview() {
-		const token = getStoredToken();
-		if (!token) {
-			elements.preview.textContent = "API 조회를 위해 토큰을 먼저 설정해 주세요.";
+	function setSectionBody(html) {
+		elements.sectionBody.innerHTML = html;
+	}
+
+	function setSectionFeedback(message, type) {
+		elements.sectionFeedback.textContent = message;
+		elements.sectionFeedback.classList.remove("feedback-info", "feedback-success", "feedback-error");
+		if (type === "success") {
+			elements.sectionFeedback.classList.add("feedback-success");
 			return;
 		}
-
-		elements.preview.textContent = "조회 중...";
-		try {
-			const data = await resolvePreviewData();
-			elements.preview.textContent = JSON.stringify(data, null, 2);
-		} catch (error) {
-			const message = error && error.message ? error.message : "알 수 없는 오류";
-			elements.preview.textContent = "요청 실패: " + message;
-			showToast(message);
+		if (type === "error") {
+			elements.sectionFeedback.classList.add("feedback-error");
+			return;
 		}
+		elements.sectionFeedback.classList.add("feedback-info");
 	}
 
-	async function resolvePreviewData() {
-		switch (state.activeNav) {
-			case "overview":
-				return Promise.all([apiClient.getSystemInfo(), apiClient.listProjects()])
-					.then(([systemInfo, projects]) => ({ systemInfo, projects }));
-			case "projects":
-				return apiClient.listProjects();
-			case "connectors":
-				return placeholderPayload("POST /v1/projects/{project_id}/connectors/loki");
-			case "llm":
-				return placeholderPayload("POST /v1/projects/{project_id}/llm-accounts/api-key");
-			case "policies":
-				return placeholderPayload("PUT /v1/projects/{project_id}/policies/*");
-			case "alerts":
-				return placeholderPayload("POST /v1/projects/{project_id}/alerts/*");
-			case "incidents":
-				return placeholderPayload("GET /v1/projects/{project_id}/incidents");
-			case "audit":
-				return placeholderPayload("GET /v1/projects/{project_id}/audit-logs");
-			default:
-				return placeholderPayload("Unknown section");
+	function setSectionHint(message) {
+		if (elements.sectionFeedback.classList.contains("feedback-success")
+			|| elements.sectionFeedback.classList.contains("feedback-error")) {
+			return;
 		}
+		setSectionFeedback(message, "info");
 	}
 
-	function placeholderPayload(endpoint) {
-		return {
-			status: "planned",
-			message: "T-20에서 상세 UI를 연결합니다.",
-			endpoint
-		};
+	function setPreview(payload) {
+		if (typeof payload === "string") {
+			elements.preview.textContent = payload;
+			return;
+		}
+		elements.preview.textContent = formatJson(payload);
+	}
+
+	function handleSectionError(prefix, error) {
+		const message = prefix + " " + errorMessage(error);
+		setSectionFeedback(message, "error");
+		setPreview({
+			status: "error",
+			message
+		});
+		showToast(message);
+	}
+
+	function errorMessage(error) {
+		if (!error) {
+			return "알 수 없는 오류";
+		}
+		if (error.message) {
+			return error.message;
+		}
+		return String(error);
 	}
 
 	function showToast(message) {
@@ -218,41 +1413,199 @@
 		return state.token;
 	}
 
+	function parseIntSafe(value) {
+		const parsed = Number.parseInt(value, 10);
+		if (Number.isNaN(parsed)) {
+			return null;
+		}
+		return parsed;
+	}
+
+	function parseFloatSafe(value) {
+		const parsed = Number.parseFloat(value);
+		if (Number.isNaN(parsed)) {
+			return null;
+		}
+		return parsed;
+	}
+
+	function safeString(value) {
+		if (value === undefined || value === null) {
+			return "";
+		}
+		return String(value);
+	}
+
+	function formatDateTime(value) {
+		if (!value) {
+			return "-";
+		}
+		const date = new Date(value);
+		if (Number.isNaN(date.getTime())) {
+			return String(value);
+		}
+		return date.toLocaleString("ko-KR", {
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+			hour12: false
+		});
+	}
+
+	function formatJson(payload) {
+		try {
+			return JSON.stringify(payload, null, 2);
+		} catch (_error) {
+			return String(payload);
+		}
+	}
+
+	function maskOAuthStartResult(response) {
+		if (!response || !response.data) {
+			return response;
+		}
+		const data = response.data;
+		return {
+			...response,
+			data: {
+				...data,
+				state: maskValue(data.state)
+			}
+		};
+	}
+
+	function maskValue(value) {
+		if (!value) {
+			return value;
+		}
+		const text = String(value);
+		if (text.length <= 8) {
+			return "****";
+		}
+		return text.slice(0, 4) + "..." + text.slice(-4);
+	}
+
+	function escapeHtml(value) {
+		return String(value)
+			.replace(/&/g, "&amp;")
+			.replace(/</g, "&lt;")
+			.replace(/>/g, "&gt;")
+			.replace(/\"/g, "&quot;")
+			.replace(/'/g, "&#39;");
+	}
+
 	function createApiClient(getToken) {
 		return {
 			getSystemInfo: () => request("/v1/system/info"),
-			listProjects: () => request("/v1/projects")
+			listProjects: () => request("/v1/projects"),
+			createProject: (payload) => request("/v1/projects", { method: "POST", body: payload }),
+			upsertLokiConnector: (projectId, payload) => request(
+				"/v1/projects/" + encode(projectId) + "/connectors/loki",
+				{ method: "POST", body: payload }
+			),
+			testLokiConnector: (projectId) => request(
+				"/v1/projects/" + encode(projectId) + "/connectors/loki/test",
+				{ method: "POST" }
+			),
+			upsertLlmApiKey: (projectId, payload) => request(
+				"/v1/projects/" + encode(projectId) + "/llm-accounts/api-key",
+				{ method: "POST", body: payload }
+			),
+			startLlmOAuth: (projectId, provider) => request(
+				"/v1/projects/" + encode(projectId) + "/llm-oauth/" + encode(provider) + "/start",
+				{ method: "POST" }
+			),
+			listLlmAccounts: (projectId) => request("/v1/projects/" + encode(projectId) + "/llm-accounts"),
+			deleteLlmAccount: (projectId, accountId) => request(
+				"/v1/projects/" + encode(projectId) + "/llm-accounts/" + encode(accountId),
+				{ method: "DELETE" }
+			),
+			updateExportPolicy: (projectId, payload) => request(
+				"/v1/projects/" + encode(projectId) + "/policies/export",
+				{ method: "PUT", body: payload }
+			),
+			updateRedactionPolicy: (projectId, payload) => request(
+				"/v1/projects/" + encode(projectId) + "/policies/redaction",
+				{ method: "PUT", body: payload }
+			),
+			configureSlack: (projectId, payload) => request(
+				"/v1/projects/" + encode(projectId) + "/alerts/slack",
+				{ method: "POST", body: payload }
+			),
+			configureEmail: (projectId, payload) => request(
+				"/v1/projects/" + encode(projectId) + "/alerts/email",
+				{ method: "POST", body: payload }
+			),
+			listIncidents: (projectId, query) => request(
+				"/v1/projects/" + encode(projectId) + "/incidents",
+				{ query }
+			),
+			getIncident: (incidentId) => request("/v1/incidents/" + encode(incidentId)),
+			reanalyzeIncident: (incidentId, payload) => request(
+				"/v1/incidents/" + encode(incidentId) + "/reanalyze",
+				{ method: "POST", body: payload }
+			),
+			listAuditLogs: (projectId, query) => request(
+				"/v1/projects/" + encode(projectId) + "/audit-logs",
+				{ query }
+			)
 		};
 
-			async function request(path, options) {
-				const config = options || {};
-				const token = getToken();
-				const hasBody = config.body !== undefined && config.body !== null;
-				const headers = {
-					"Accept": "application/json",
-					...config.headers
-				};
-				if (hasBody) {
-					headers["Content-Type"] = "application/json";
-				}
-				if (token) {
-					headers.Authorization = "Bearer " + token;
-				}
-
-				const response = await fetch(path, {
-					method: config.method || "GET",
-					headers,
-					body: hasBody ? JSON.stringify(config.body) : undefined
-				});
-
-			const text = await response.text();
-			const payload = parseJson(text);
-
-			if (!response.ok) {
-				throw normalizeApiError(response.status, payload);
+		function request(path, options) {
+			const config = options || {};
+			const token = getToken();
+			const hasBody = config.body !== undefined && config.body !== null;
+			const headers = {
+				"Accept": "application/json",
+				...config.headers
+			};
+			if (hasBody) {
+				headers["Content-Type"] = "application/json";
 			}
-			return payload;
+			if (token) {
+				headers.Authorization = "Bearer " + token;
+			}
+
+			const responsePath = appendQuery(path, config.query);
+			return fetch(responsePath, {
+				method: config.method || "GET",
+				headers,
+				body: hasBody ? JSON.stringify(config.body) : undefined
+			}).then(async (response) => {
+				const text = await response.text();
+				const payload = parseJson(text);
+				if (!response.ok) {
+					throw normalizeApiError(response.status, payload);
+				}
+				return payload;
+			});
 		}
+	}
+
+	function appendQuery(path, query) {
+		if (!query) {
+			return path;
+		}
+		const params = new URLSearchParams();
+		Object.keys(query).forEach((key) => {
+			const value = query[key];
+			if (value === undefined || value === null || value === "") {
+				return;
+			}
+			params.set(key, String(value));
+		});
+		const queryString = params.toString();
+		if (!queryString) {
+			return path;
+		}
+		return path + "?" + queryString;
+	}
+
+	function encode(value) {
+		return encodeURIComponent(String(value));
 	}
 
 	function parseJson(text) {

--- a/src/main/resources/static/admin/app.js
+++ b/src/main/resources/static/admin/app.js
@@ -127,13 +127,7 @@
 
 	function clearCachedData() {
 		state.projects = [];
-		state.activeProjectId = "";
-		state.llmAccounts = [];
-		state.incidents = [];
-		state.incidentMeta = null;
-		state.selectedIncident = null;
-		state.auditLogs = [];
-		state.auditMeta = null;
+		updateActiveProject("");
 	}
 
 	function validateRequiredElements() {
@@ -303,7 +297,7 @@
 					});
 					await refreshProjects();
 					if (created && created.data && created.data.id) {
-						state.activeProjectId = created.data.id;
+						updateActiveProject(created.data.id);
 						renderActiveProject();
 					}
 					setSectionFeedback("프로젝트가 생성되었습니다.", "success");
@@ -331,7 +325,7 @@
 		selectButtons.forEach((button) => {
 			button.addEventListener("click", () => {
 				const projectId = button.getAttribute("data-project-id") || "";
-				state.activeProjectId = projectId;
+				updateActiveProject(projectId);
 				renderActiveProject();
 				setSectionFeedback("활성 프로젝트를 선택했습니다: " + projectId, "success");
 				renderProjectsSection();
@@ -564,23 +558,27 @@
 
 		oauthButtons.forEach((button) => {
 			button.addEventListener("click", async () => {
+				const popup = window.open("", "_blank", "noopener,noreferrer");
 				try {
 					requireToken();
 					const provider = button.getAttribute("data-provider") || "openai";
 					const response = await apiClient.startLlmOAuth(projectId, provider);
 					const masked = maskOAuthStartResult(response);
-					const authUrl = response && response.data ? response.data.auth_url : null;
+					const authUrl = validateOAuthAuthUrl(response && response.data ? response.data.auth_url : null);
 					if (resultBox) {
 						resultBox.textContent = formatJson(masked);
 					}
-					if (authUrl) {
-						window.open(authUrl, "_blank", "noopener,noreferrer");
+					if (popup && !popup.closed) {
+						popup.location.replace(authUrl);
 						setSectionFeedback(provider + " OAuth 인증 페이지를 새 창으로 열었습니다.", "success");
 					} else {
-						setSectionFeedback(provider + " OAuth 시작 URL이 생성되었습니다.", "success");
+						setSectionFeedback(provider + " OAuth 팝업이 차단되어 URL을 미리보기로만 표시했습니다.", "error");
 					}
 					setPreview(masked);
 				} catch (error) {
+					if (popup && !popup.closed) {
+						popup.close();
+					}
 					handleSectionError("OAuth 시작 URL 생성에 실패했습니다.", error);
 				}
 			});
@@ -1079,12 +1077,12 @@
 
 	function reconcileActiveProject() {
 		if (state.projects.length === 0) {
-			state.activeProjectId = "";
+			updateActiveProject("");
 			return;
 		}
 		const exists = state.projects.some((project) => project && project.id === state.activeProjectId);
 		if (!exists) {
-			state.activeProjectId = state.projects[0] && state.projects[0].id ? state.projects[0].id : "";
+			updateActiveProject(state.projects[0] && state.projects[0].id ? state.projects[0].id : "");
 		}
 	}
 
@@ -1259,14 +1257,21 @@
 			return [];
 		}
 		return lines.map((line, index) => {
-			const tokens = line.split("|").map((token) => token.trim());
-			if (tokens.length < 3) {
+			const firstDelimiterIndex = line.indexOf("|");
+			const lastDelimiterIndex = line.lastIndexOf("|");
+			if (firstDelimiterIndex < 0 || lastDelimiterIndex <= firstDelimiterIndex) {
+				throw new Error("redaction rules 형식 오류 (line " + (index + 1) + "): name|pattern|replace_with");
+			}
+			const name = line.slice(0, firstDelimiterIndex).trim();
+			const pattern = line.slice(firstDelimiterIndex + 1, lastDelimiterIndex).trim();
+			const replaceWith = line.slice(lastDelimiterIndex + 1).trim();
+			if (!name || !pattern || !replaceWith) {
 				throw new Error("redaction rules 형식 오류 (line " + (index + 1) + "): name|pattern|replace_with");
 			}
 			return {
-				name: tokens[0],
-				pattern: tokens[1],
-				replace_with: tokens.slice(2).join("|")
+				name,
+				pattern,
+				replace_with: replaceWith
 			};
 		});
 	}
@@ -1324,6 +1329,24 @@
 
 	function selected(value, expected) {
 		return value === expected ? " selected" : "";
+	}
+
+	function resetProjectScopedState() {
+		state.llmAccounts = [];
+		state.incidents = [];
+		state.incidentMeta = null;
+		state.selectedIncident = null;
+		state.auditLogs = [];
+		state.auditMeta = null;
+	}
+
+	function updateActiveProject(projectId) {
+		const nextProjectId = projectId || "";
+		if (state.activeProjectId === nextProjectId) {
+			return;
+		}
+		state.activeProjectId = nextProjectId;
+		resetProjectScopedState();
 	}
 
 	function renderActiveProject() {
@@ -1486,6 +1509,23 @@
 			return "****";
 		}
 		return text.slice(0, 4) + "..." + text.slice(-4);
+	}
+
+	function validateOAuthAuthUrl(urlValue) {
+		if (!urlValue) {
+			throw new Error("OAuth 시작 URL이 비어 있습니다.");
+		}
+		let parsed;
+		try {
+			parsed = new URL(urlValue);
+		} catch (_error) {
+			throw new Error("OAuth 시작 URL 형식이 올바르지 않습니다.");
+		}
+		const protocol = parsed.protocol.toLowerCase();
+		if (protocol !== "http:" && protocol !== "https:") {
+			throw new Error("OAuth 시작 URL은 http/https 스킴이어야 합니다.");
+		}
+		return parsed.toString();
 	}
 
 	function escapeHtml(value) {

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -44,9 +44,19 @@
 				<p id="auth-status" class="status-text" role="status">토큰이 아직 설정되지 않았습니다.</p>
 			</section>
 
-			<section class="card">
-				<h2 id="section-title">개요</h2>
-				<p id="section-description">T-20에서 도메인 화면이 이 영역으로 확장됩니다.</p>
+			<section class="card workspace-card">
+				<div class="card-header">
+					<div>
+						<h2 id="section-title">개요</h2>
+						<p id="section-description">T-20 운영 화면을 이 영역에서 수행합니다.</p>
+					</div>
+					<div class="project-chip-wrap" aria-live="polite">
+						<span class="chip-label">활성 프로젝트</span>
+						<code id="active-project-id">없음</code>
+					</div>
+				</div>
+				<p id="section-feedback" class="section-feedback">섹션을 선택하고 작업을 시작하세요.</p>
+				<div id="section-body" class="section-body"></div>
 			</section>
 
 			<section class="card">

--- a/src/main/resources/static/admin/styles.css
+++ b/src/main/resources/static/admin/styles.css
@@ -255,6 +255,202 @@ button.secondary {
 	margin-bottom: 0.55rem;
 }
 
+.card.workspace-card > .card-header {
+	align-items: flex-start;
+}
+
+.project-chip-wrap {
+	display: grid;
+	gap: 0.2rem;
+	justify-items: end;
+}
+
+.chip-label {
+	font-size: 0.74rem;
+	font-weight: 600;
+	color: var(--text-subtle);
+}
+
+#active-project-id {
+	display: inline-flex;
+	padding: 0.2rem 0.5rem;
+	border-radius: 999px;
+	background: rgba(11, 95, 63, 0.1);
+	border: 1px solid rgba(11, 95, 63, 0.22);
+	font-size: 0.8rem;
+	color: var(--accent-strong);
+}
+
+.section-feedback {
+	margin-top: 0.15rem;
+	margin-bottom: 0.85rem;
+	font-size: 0.88rem;
+	padding: 0.44rem 0.6rem;
+	border-radius: 9px;
+	border: 1px solid transparent;
+}
+
+.feedback-info {
+	background: rgba(45, 89, 70, 0.08);
+	border-color: rgba(24, 66, 49, 0.18);
+	color: #234e3e;
+}
+
+.feedback-success {
+	background: rgba(13, 125, 84, 0.14);
+	border-color: rgba(13, 125, 84, 0.3);
+	color: #114735;
+}
+
+.feedback-error {
+	background: rgba(174, 47, 47, 0.12);
+	border-color: rgba(174, 47, 47, 0.32);
+	color: #7e2525;
+}
+
+.section-body {
+	display: grid;
+	gap: 0.85rem;
+}
+
+.workspace-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.85rem;
+}
+
+.section-body .workspace-card {
+	border-radius: 12px;
+	padding: 0.85rem 0.92rem;
+	background: rgba(255, 255, 255, 0.68);
+	border: 1px solid rgba(18, 35, 28, 0.11);
+}
+
+.section-body .workspace-card h3 {
+	margin: 0 0 0.55rem;
+	font-size: 0.98rem;
+}
+
+.muted {
+	color: var(--text-subtle);
+	font-size: 0.85rem;
+	margin-bottom: 0.6rem;
+}
+
+.empty-state {
+	padding: 0.6rem 0.65rem;
+	border-radius: 10px;
+	background: rgba(61, 89, 76, 0.08);
+	border: 1px dashed rgba(61, 89, 76, 0.28);
+}
+
+.form-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0.44rem;
+}
+
+.form-grid-inline {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	align-items: end;
+}
+
+.form-grid label {
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: #1f4033;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+	width: 100%;
+	border: 1px solid rgba(26, 46, 37, 0.2);
+	border-radius: 8px;
+	padding: 0.5rem 0.56rem;
+	font-size: 0.88rem;
+	background: var(--panel-strong);
+	color: var(--text-main);
+}
+
+.form-grid textarea {
+	resize: vertical;
+	min-height: 2.5rem;
+}
+
+.form-grid input:focus-visible,
+.form-grid select:focus-visible,
+.form-grid textarea:focus-visible {
+	outline: 2px solid rgba(13, 125, 84, 0.35);
+	outline-offset: 1px;
+}
+
+.checkbox-row {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.45rem;
+}
+
+.checkbox-row input {
+	width: auto;
+}
+
+.inline-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+	margin-top: 0.2rem;
+}
+
+.form-grid .inline-actions {
+	grid-column: 1 / -1;
+}
+
+.table-wrap {
+	overflow: auto;
+	border: 1px solid rgba(26, 46, 37, 0.14);
+	border-radius: 9px;
+	background: rgba(255, 255, 255, 0.62);
+}
+
+.data-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.82rem;
+}
+
+.data-table th,
+.data-table td {
+	padding: 0.5rem 0.54rem;
+	border-bottom: 1px solid rgba(26, 46, 37, 0.1);
+	text-align: left;
+	vertical-align: top;
+}
+
+.data-table thead th {
+	background: rgba(224, 235, 229, 0.7);
+	font-weight: 700;
+	color: #204133;
+}
+
+.pill {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.14rem 0.46rem;
+	border-radius: 999px;
+	background: rgba(13, 125, 84, 0.16);
+	color: #124e39;
+	font-weight: 700;
+}
+
+.table-pre {
+	margin: 0;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-size: 0.73rem;
+	line-height: 1.32;
+}
+
 .preview {
 	margin: 0;
 	padding: 0.75rem;
@@ -266,6 +462,12 @@ button.secondary {
 	overflow: auto;
 	font-size: 0.84rem;
 	line-height: 1.4;
+}
+
+.preview-inline {
+	min-height: 140px;
+	max-height: 320px;
+	margin-top: 0.6rem;
 }
 
 .toast {
@@ -300,6 +502,14 @@ button.secondary {
 	.nav-item {
 		text-align: center;
 	}
+
+	.workspace-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.form-grid-inline {
+		grid-template-columns: 1fr;
+	}
 }
 
 @media (max-width: 620px) {
@@ -309,6 +519,14 @@ button.secondary {
 
 	.nav-panel {
 		grid-template-columns: 1fr;
+	}
+
+	.project-chip-wrap {
+		justify-items: start;
+	}
+
+	.card.workspace-card > .card-header {
+		flex-direction: column;
 	}
 }
 

--- a/src/main/resources/static/admin/styles.css
+++ b/src/main/resources/static/admin/styles.css
@@ -446,7 +446,8 @@ button.secondary {
 .table-pre {
 	margin: 0;
 	white-space: pre-wrap;
-	word-break: break-word;
+	word-break: normal;
+	overflow-wrap: anywhere;
 	font-size: 0.73rem;
 	line-height: 1.32;
 }

--- a/src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java
+++ b/src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java
@@ -73,4 +73,45 @@ class AdminUiIntegrationTest {
 			.andExpect(content().string(containsString("@media (max-width: 620px)")))
 			.andExpect(content().string(containsString(":focus-visible")));
 	}
+
+	@Test
+	@DisplayName("admin shell 은 T-20 운영 워크스페이스 골격을 포함한다")
+	void adminShellContainsOperationalWorkspaceScaffold() throws Exception {
+		mockMvc.perform(get("/admin/index.html"))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("data-nav=\"projects\"")))
+			.andExpect(content().string(containsString("data-nav=\"connectors\"")))
+			.andExpect(content().string(containsString("data-nav=\"llm\"")))
+			.andExpect(content().string(containsString("data-nav=\"policies\"")))
+			.andExpect(content().string(containsString("data-nav=\"alerts\"")))
+			.andExpect(content().string(containsString("data-nav=\"incidents\"")))
+			.andExpect(content().string(containsString("data-nav=\"audit\"")))
+			.andExpect(content().string(containsString("id=\"active-project-id\"")))
+			.andExpect(content().string(containsString("id=\"section-feedback\"")))
+			.andExpect(content().string(containsString("id=\"section-body\"")));
+	}
+
+	@Test
+	@DisplayName("admin app script 는 T-20 운영 API 경로와 렌더러를 포함한다")
+	void adminAppScriptContainsOperationalEndpointsAndRenderers() throws Exception {
+		mockMvc.perform(get("/admin/app.js"))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("renderProjectsSection")))
+			.andExpect(content().string(containsString("renderConnectorsSection")))
+			.andExpect(content().string(containsString("renderLlmSection")))
+			.andExpect(content().string(containsString("renderPoliciesSection")))
+			.andExpect(content().string(containsString("renderAlertsSection")))
+			.andExpect(content().string(containsString("renderIncidentsSection")))
+			.andExpect(content().string(containsString("renderAuditSection")))
+			.andExpect(content().string(containsString("window.open(")))
+			.andExpect(content().string(containsString("maskOAuthStartResult")))
+			.andExpect(content().string(containsString("/v1/projects")))
+			.andExpect(content().string(containsString("/connectors/loki")))
+			.andExpect(content().string(containsString("/llm-accounts/api-key")))
+			.andExpect(content().string(containsString("/policies/export")))
+			.andExpect(content().string(containsString("/alerts/slack")))
+			.andExpect(content().string(containsString("/alerts/email")))
+			.andExpect(content().string(containsString("/v1/incidents/")))
+			.andExpect(content().string(containsString("/audit-logs")));
+	}
 }


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - Admin UI의 T-20 범위 운영 화면(프로젝트/커넥터/LLM/정책/알림/인시던트/audit)을 구현했다.
  - 인시던트 상세/재분석, audit cursor/limit 조회, 실패 UX(피드백/토스트)를 추가했다.
  - OAuth start UX를 보완해 auth URL 새 창 오픈과 state 마스킹 출력을 적용했다.
- 왜 필요한가:
  - T-19에서 구축한 UI 기반 위에 실제 운영 플로우를 올려 MVP의 backend-embedded Admin UI 범위를 완성하기 위해 필요하다.

## 연결 이슈
- Closes #47

## 범위 점검
- 포함:
  - `/admin` 워크스페이스 확장(`active-project-id`, `section-feedback`, `section-body`)
  - 도메인별 UI 섹션 렌더러/폼/조회/액션 구현
  - UI 통합 회귀 테스트(`AdminUiIntegrationTest`) 보강
  - 세션 노트 `docs/sessions/2026-03-04-T-20.md` 작성
- 제외:
  - 신규 OpenAPI 엔드포인트 추가
  - SQLite 영속화/secret 저장소 전환(T-21)
  - 인증 모델 재설계(T-19 경계 유지)

## 주요 변경 사항
- 변경 1
  - `src/main/resources/static/admin/app.js`에 섹션 렌더러 8종(overview/projects/connectors/llm/policies/alerts/incidents/audit) 및 API client 경로를 구현.
- 변경 2
  - OAuth start 버튼에서 `window.open(auth_url)`를 수행하고 `state`를 마스킹해 UI 노출을 완화.
- 변경 3
  - `setSectionHint`를 도입해 섹션 재렌더 시 성공/오류 피드백이 info 메시지로 덮이는 UX 회귀를 수정.
- 변경 4
  - `src/main/resources/static/admin/index.html`, `styles.css`를 운영 워크스페이스/폼/테이블/반응형 스타일로 확장.
- 변경 5
  - `src/test/java/com/logcopilot/ui/AdminUiIntegrationTest.java`에 T-20 워크스페이스/렌더러/API 경로/OAuth 처리 문자열 검증 추가.

## TDD 근거
- RED:
  - `./gradlew test --tests "*AdminUiIntegrationTest"` 실행 시 T-20 워크스페이스/렌더러 검증 2건 실패.
- GREEN:
  - 구현 후 `./gradlew test --tests "*AdminUiIntegrationTest"` PASS.
  - `./gradlew test --tests "*Ui*Test" --tests "*EndpointsContractTest"` PASS.
- REFACTOR:
  - 딴지 리뷰 피드백 반영(OAuth 시작 UX, 피드백 유지 로직, state 마스킹).

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC7 -> `./gradlew test --tests "*Ui*Test" --tests "*EndpointsContractTest"` -> PASS
- AC7 -> `./gradlew test --tests "*AdminUiIntegrationTest"` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - (PR 생성 후 반영 예정)
- codex:
  - 딴지 리뷰(Explorer) 지적 반영 완료:
    - OAuth start 새 창 오픈
    - 성공 피드백 유지(`setSectionHint`)
    - OAuth state 마스킹

## 리스크 / 롤백
- 확인된 리스크:
  - UI 테스트는 정적/MockMvc 중심이라 브라우저 상호작용 E2E 공백이 남아 있다.
- 롤백 계획:
  - 본 PR의 단일 커밋 revert로 T-19 UI shell 상태로 복귀 가능.

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-21에서 SQLite 영속화 전환 시 T-20 UI 액션 경로 회귀를 우선 검증.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트 관리 기능 추가
  * Loki 커넥터, LLM 계정, 정책, 알림, 인시던트, 감사 로그 관리 인터페이스
  * 활성 프로젝트 선택 및 표시 기능
  * 향상된 오류 처리 및 사용자 피드백

* **문서**
  * 운영 기능 구현 세션 문서 추가

* **테스트**
  * 관리 UI 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->