### PR TITLE
[WU-21] T-21 SQLite 영속화 + 시크릿 보호 저장소 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+data/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	implementation 'org.springframework:spring-jdbc'
+	implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docs/sessions/2026-03-04-T-21.md
+++ b/docs/sessions/2026-03-04-T-21.md
@@ -113,3 +113,23 @@ Use `docs/templates/commit-message.template.md`.
   - T-22
 - Suggested first check for next session:
   - T-22에서 `check/test/build` 최종 게이트와 SLO 증거 문서화 시, SQLite on-path 통합 시나리오를 운영 검증 명령에 포함할 것.
+
+## 9. PR Review Follow-up
+- 반영 항목:
+  - `logcopilot.persistence.sqlite.path` -> `logcopilot.persistence.sqlite-path`로 변경해 바인딩 오류를 제거.
+  - `PersistenceProperties` 기본 암호화 키 제거 + enabled=true 시 누락 즉시 부팅 실패 검증 추가.
+  - `application.properties`의 고정 암호화 키 제거, 환경 변수 주입 안내 주석 추가.
+  - `SqlitePersistenceConfiguration`에서 `jdbc:sqlite:file:...`/query 파라미터 경로 처리 안전화.
+  - `StateCipher`를 PBKDF2(`PBKDF2WithHmacSHA256`) + salt 포함 포맷으로 강화하고 레거시 복호화 호환 유지.
+  - `LokiConnectorService` upsert 저장 실패 시 메모리 상태 롤백 보장.
+  - `SqliteLokiPullCursorStore`를 SQL 원자 upsert(`max(existing, excluded)`)로 변경.
+  - 테스트 고정 키 문자열 제거(테스트별 ephemeral 값 생성/재사용).
+  - 회귀 방지 테스트 추가:
+    - `PersistencePropertiesTest`
+    - `StateCipherTest`
+    - `LokiConnectorServiceTest`
+    - `SqliteLokiPullCursorStoreTest`
+- 재검증:
+  - `./gradlew check` -> PASS
+  - `./gradlew test` -> PASS
+  - `./gradlew build` -> PASS

--- a/docs/sessions/2026-03-04-T-21.md
+++ b/docs/sessions/2026-03-04-T-21.md
@@ -1,0 +1,115 @@
+# Session Task Note - T-21
+
+## Metadata
+- Date: 2026-03-04
+- Issue: #49
+- Branch: `feature/49-t21-sqlite-persistence-security`
+- Task ID: T-21
+- Related spec: `docs/specs/2026-03-04-mvp-v1-post-t11-delivery-plan.md`
+
+## 1. Intent Check
+- Do now:
+  - in-memory 상태(프로젝트/커넥터/LLM/정책/알림/audit/incident)를 SQLite 스냅샷으로 복원 가능하게 전환한다.
+  - secret 저장값은 암호화 payload로 저장하고, ingest 토큰 검증은 hash 저장소 기반으로 전환한다.
+  - Loki pull cursor를 SQLite 저장소로 전환하고 재시작 복원 테스트를 추가한다.
+- Do not do now:
+  - 신규 OpenAPI 엔드포인트 추가.
+  - SLO 측정/운영 하드닝 종료(T-22 범위).
+  - main/develop 직접 작업.
+- Done means:
+  - 재시작 후 주요 상태가 복원된다.
+  - DB 파일에 secret/token 원문이 저장되지 않는다.
+  - audit 로그가 재시작 후 유지되고 append-only로 누적된다.
+- Source-of-truth order checked (`docs/domain/source-of-truth.md`):
+  - `product-direction -> openapi -> architecture-guardrails -> workflow -> active spec` 순으로 확인.
+- MVP scope gate (`docs/domain/product-direction.md`):
+  - SQLite 기본 저장소, secret 보호 저장, audit 보존은 MVP 고정 결정 in-scope.
+- AC-to-rule mapping to execute:
+  - AC8 -> Integration/Security -> `./gradlew test --tests "*SqlitePersistenceTest" --tests "*AuditPersistenceTest" --tests "*BearerTokenValidatorTest"` -> PASS
+  - Gate -> `./gradlew check` -> PASS
+  - Gate -> `./gradlew test` -> PASS
+  - Gate -> `./gradlew build` -> PASS
+
+## 2. Plan (Short)
+1. RED: 재시작 복원/secret 보호/audit append-only 통합 테스트를 먼저 추가한다.
+2. GREEN: SQLite + 암호화 스냅샷 계층과 hash 토큰 저장소를 도입하고 서비스별 상태 저장 훅을 연결한다.
+3. REFACTOR: 딴지 리뷰(로드 실패 시 삭제, 인증 500 회귀, incident 복원 검증 누락)를 반영한다.
+
+## 3. TDD Evidence
+- RED tests written first:
+  - `src/test/java/com/logcopilot/persistence/SqlitePersistenceTest.java`
+  - `src/test/java/com/logcopilot/alert/AuditPersistenceTest.java`
+- RED failure output summary:
+  - 재시작 후 project/audit 상태가 복원되지 않아 `NotFoundException` 및 assertion 실패.
+  - secret/hash 검증 시 SQLite 저장 계층 부재로 테이블/드라이버 관련 실패.
+- GREEN pass output summary:
+  - `./gradlew test --tests "*SqlitePersistenceTest" --tests "*AuditPersistenceTest"` -> PASS
+  - `./gradlew test --tests "*BearerTokenValidatorTest"` -> PASS
+- REFACTOR summary:
+  - 스냅샷 load 실패 시 row 삭제를 제거하고 경고 후 skip하도록 변경(데이터 복구 가능성 보존).
+  - hash 저장소 장애 시 `BearerTokenValidator`가 `UnauthorizedException`으로 변환하도록 보완.
+  - 재시작 복원 테스트에 incident 복원 검증을 추가.
+
+## 4. Implementation Notes
+- Key file changes:
+  - `build.gradle`
+    - `spring-jdbc`, `sqlite-jdbc` 의존성 추가.
+  - `src/main/java/com/logcopilot/common/persistence/PersistenceProperties.java`
+  - `src/main/java/com/logcopilot/common/persistence/SqlitePersistenceConfiguration.java`
+  - `src/main/java/com/logcopilot/common/persistence/StateCipher.java`
+  - `src/main/java/com/logcopilot/common/persistence/StateSnapshotRepository.java`
+  - `src/main/java/com/logcopilot/common/persistence/SqliteStateSnapshotRepository.java`
+  - `src/main/java/com/logcopilot/common/persistence/TokenHashStore.java`
+  - `src/main/java/com/logcopilot/common/persistence/SqliteTokenHashStore.java`
+  - `src/main/java/com/logcopilot/project/ProjectService.java`
+  - `src/main/java/com/logcopilot/connector/LokiConnectorService.java`
+  - `src/main/java/com/logcopilot/llm/LlmAccountService.java`
+  - `src/main/java/com/logcopilot/policy/PolicyService.java`
+  - `src/main/java/com/logcopilot/alert/AlertService.java`
+  - `src/main/java/com/logcopilot/incident/IncidentService.java`
+  - `src/main/java/com/logcopilot/common/auth/BearerTokenValidator.java`
+  - `src/main/java/com/logcopilot/connector/SqliteLokiPullCursorStore.java`
+  - `src/main/resources/application.properties`
+  - `src/test/resources/application.properties`
+  - `src/test/java/com/logcopilot/persistence/SqlitePersistenceTest.java`
+  - `src/test/java/com/logcopilot/alert/AuditPersistenceTest.java`
+  - `src/test/java/com/logcopilot/common/auth/BearerTokenValidatorTest.java`
+  - `.gitignore`
+- Why this approach:
+  - 서비스 로직을 크게 깨지 않고 스냅샷 기반으로 영속화/복원을 도입해 T-21 범위를 한 세션에서 안정적으로 완료할 수 있다.
+  - secret은 암호화 payload로 저장하고, ingest token은 SHA-256 hash lookup만 수행해 원문 저장을 차단한다.
+
+## 5. Verification
+- Commands:
+  - `./gradlew test --tests "*SqlitePersistenceTest" --tests "*AuditPersistenceTest"`
+  - `./gradlew test --tests "*BearerTokenValidatorTest"`
+  - `./gradlew check && ./gradlew test && ./gradlew build`
+- Results:
+  - 모든 명령 PASS.
+
+## 6. Challenge Review ("딴지")
+- Reviewer model/agent:
+  - Explorer sub-agent `Harvey`
+- Findings:
+  - Critical: 복원 실패 시 스냅샷 row를 삭제해 영구 유실 가능.
+  - High: hash 저장소 장애 시 인증 경로에서 500 회귀 가능.
+  - Medium: incident 복원 검증 누락.
+- Resolution:
+  - `SqliteStateSnapshotRepository` load 실패 시 삭제 제거 + warn/skip.
+  - `BearerTokenValidator`에서 hash 저장소 예외를 `UnauthorizedException`으로 정규화.
+  - `SqlitePersistenceTest`에 incident 복원 검증 추가.
+- Residual risk:
+  - 테스트 기본 환경에서 persistence를 비활성화했으므로 일반 계약 테스트는 SQLite 경로를 기본으로 타지 않는다.
+  - SQLite 경로 상시 검증 범위는 T-21 전용 통합 테스트로 보완 중.
+
+## 7. Commit Draft
+Use `docs/templates/commit-message.template.md`.
+
+## 8. Next Handoff
+- Remaining risk:
+  - 스냅샷 저장 실패는 현재 warn 후 진행하도록 설계되어, 장애 시 일시적 메모리-디스크 불일치가 발생할 수 있다.
+  - SQLite 스냅샷은 서비스 단위 atomicity가 없어 다중 서비스 동시 업데이트 경계는 후속 개선 여지가 있다.
+- Next task ID:
+  - T-22
+- Suggested first check for next session:
+  - T-22에서 `check/test/build` 최종 게이트와 SLO 증거 문서화 시, SQLite on-path 통합 시나리오를 운영 검증 명령에 포함할 것.

--- a/src/main/java/com/logcopilot/alert/AlertService.java
+++ b/src/main/java/com/logcopilot/alert/AlertService.java
@@ -2,7 +2,9 @@ package com.logcopilot.alert;
 
 import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.common.error.ValidationException;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
 import com.logcopilot.project.ProjectService;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ import java.util.regex.Pattern;
 @Service
 public class AlertService {
 
+	private static final String SNAPSHOT_SCOPE = "alert-service";
 	private static final int DEFAULT_LIMIT = 50;
 	private static final int MAX_LIMIT = 200;
 	private static final double DEFAULT_MIN_CONFIDENCE = 0.45d;
@@ -52,6 +55,7 @@ public class AlertService {
 	private final Duration stormScopeRetention;
 	private final AlertStormPolicy alertStormPolicy;
 	private final Clock clock;
+	private final StateSnapshotRepository stateSnapshotRepository;
 	private final Map<String, Map<String, AlertChannelState>> channelsByProject = new HashMap<>();
 	private final Map<String, List<AuditLogState>> auditLogsByProject = new HashMap<>();
 	private final Map<String, Instant> lastDispatchAtByProject = new HashMap<>();
@@ -89,7 +93,8 @@ public class AlertService {
 		@Value("${logcopilot.alert.storm.quiet-hours.end:07:00}") String quietHoursEnd,
 		@Value("${logcopilot.alert.storm.quiet-hours.zone:UTC}") String quietHoursZone,
 		@Value("${logcopilot.alert.storm.max-scopes:10000}") int maxStormScopeEntries,
-		@Value("${logcopilot.alert.storm.scope-retention:PT24H}") Duration stormScopeRetention
+		@Value("${logcopilot.alert.storm.scope-retention:PT24H}") Duration stormScopeRetention,
+		ObjectProvider<StateSnapshotRepository> stateSnapshotRepositoryProvider
 	) {
 		this(
 			projectService,
@@ -105,7 +110,8 @@ public class AlertService {
 			),
 			Clock.systemUTC(),
 			maxStormScopeEntries,
-			stormScopeRetention
+			stormScopeRetention,
+			stateSnapshotRepositoryProvider.getIfAvailable()
 		);
 	}
 
@@ -121,7 +127,8 @@ public class AlertService {
 			alertStormPolicy,
 			clock,
 			DEFAULT_MAX_STORM_SCOPE_ENTRIES,
-			DEFAULT_STORM_SCOPE_RETENTION
+			DEFAULT_STORM_SCOPE_RETENTION,
+			null
 		);
 	}
 
@@ -131,7 +138,8 @@ public class AlertService {
 		AlertStormPolicy alertStormPolicy,
 		Clock clock,
 		int maxStormScopeEntries,
-		Duration stormScopeRetention
+		Duration stormScopeRetention,
+		StateSnapshotRepository stateSnapshotRepository
 	) {
 		if (maxAuditLogsPerProject < 1) {
 			throw new IllegalArgumentException("maxAuditLogsPerProject must be >= 1");
@@ -154,6 +162,8 @@ public class AlertService {
 		this.stormScopeRetention = stormScopeRetention;
 		this.alertStormPolicy = alertStormPolicy;
 		this.clock = clock;
+		this.stateSnapshotRepository = stateSnapshotRepository;
+		restoreState();
 	}
 
 	public synchronized ConfigureResult configureSlack(
@@ -189,7 +199,7 @@ public class AlertService {
 				"created", result.created()
 			)
 		);
-
+		persistState();
 		return result;
 	}
 
@@ -231,7 +241,7 @@ public class AlertService {
 				"created", result.created()
 			)
 		);
-
+		persistState();
 		return result;
 	}
 
@@ -244,18 +254,26 @@ public class AlertService {
 		Instant now = clock.instant();
 		evictStormScopeState(now);
 		String scopeKey = dispatchScopeKey(projectId, safeCommand.service());
-
+		AlertDispatchResult result;
 		if (!hasEnabledChannel(projectId)) {
-			return suppressDispatch(projectId, safeCommand, "no_channel_configured", now);
+			result = suppressDispatch(projectId, safeCommand, "no_channel_configured", now);
+			persistState();
+			return result;
 		}
 		if (isQuietHours(now)) {
-			return suppressDispatch(projectId, safeCommand, "quiet_hours", now);
+			result = suppressDispatch(projectId, safeCommand, "quiet_hours", now);
+			persistState();
+			return result;
 		}
 		if (isInCooldown(scopeKey, now)) {
-			return suppressDispatch(projectId, safeCommand, "cooldown", now);
+			result = suppressDispatch(projectId, safeCommand, "cooldown", now);
+			persistState();
+			return result;
 		}
 		if (isRateBudgetExceeded(scopeKey, now)) {
-			return suppressDispatch(projectId, safeCommand, "rate_budget_exceeded", now);
+			result = suppressDispatch(projectId, safeCommand, "rate_budget_exceeded", now);
+			persistState();
+			return result;
 		}
 
 		recordSuccessfulDispatch(scopeKey, now);
@@ -267,7 +285,9 @@ public class AlertService {
 			safeCommand.incidentId(),
 			dispatchMetadata(safeCommand, "dispatched")
 		);
-		return new AlertDispatchResult(true, "dispatched", now);
+		result = new AlertDispatchResult(true, "dispatched", now);
+		persistState();
+		return result;
 	}
 
 	public synchronized void recordDispatchFailure(
@@ -287,6 +307,7 @@ public class AlertService {
 			safeCommand.incidentId(),
 			dispatchMetadata(safeCommand, normalizeFailureReason(reason))
 		);
+		persistState();
 	}
 
 	public synchronized AuditLogListResult listAuditLogs(String projectId, AuditLogQuery query) {
@@ -540,8 +561,10 @@ public class AlertService {
 			clock.instant(),
 			Map.copyOf(metadata)
 		));
-		while (logs.size() > maxAuditLogsPerProject) {
-			logs.remove(0);
+		if (stateSnapshotRepository == null) {
+			while (logs.size() > maxAuditLogsPerProject) {
+				logs.remove(0);
+			}
 		}
 	}
 
@@ -794,7 +817,7 @@ public class AlertService {
 	) {
 	}
 
-	private record AlertChannelState(
+	record AlertChannelState(
 		String id,
 		String type,
 		boolean enabled,
@@ -803,14 +826,14 @@ public class AlertService {
 	) {
 	}
 
-	private record SlackConfig(
+	record SlackConfig(
 		String webhookUrl,
 		String channel,
 		double minConfidence
 	) {
 	}
 
-	private record EmailConfig(
+	record EmailConfig(
 		String from,
 		List<String> recipients,
 		SmtpConfig smtp,
@@ -818,7 +841,7 @@ public class AlertService {
 	) {
 	}
 
-	private record SmtpConfig(
+	record SmtpConfig(
 		String host,
 		int port,
 		String username,
@@ -827,7 +850,7 @@ public class AlertService {
 	) {
 	}
 
-	private record AuditLogState(
+	record AuditLogState(
 		String id,
 		String actor,
 		String action,
@@ -838,9 +861,72 @@ public class AlertService {
 	) {
 	}
 
-	private record DispatchBudgetState(
+	record DispatchBudgetState(
 		Instant windowStart,
 		int sentCount
+	) {
+	}
+
+	private void restoreState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.load(SNAPSHOT_SCOPE, AlertServiceSnapshot.class)
+			.ifPresent(snapshot -> {
+				channelsByProject.clear();
+				auditLogsByProject.clear();
+				lastDispatchAtByProject.clear();
+				dispatchBudgetByProject.clear();
+
+				if (snapshot.channelsByProject() != null) {
+					snapshot.channelsByProject().forEach((projectId, channels) -> channelsByProject.put(
+						projectId,
+						channels == null ? new LinkedHashMap<>() : new LinkedHashMap<>(channels)
+					));
+				}
+				if (snapshot.auditLogsByProject() != null) {
+					snapshot.auditLogsByProject().forEach((projectId, logs) -> auditLogsByProject.put(
+						projectId,
+						logs == null ? new ArrayList<>() : new ArrayList<>(logs)
+					));
+				}
+				if (snapshot.lastDispatchAtByProject() != null) {
+					lastDispatchAtByProject.putAll(snapshot.lastDispatchAtByProject());
+				}
+				if (snapshot.dispatchBudgetByProject() != null) {
+					dispatchBudgetByProject.putAll(snapshot.dispatchBudgetByProject());
+				}
+			});
+	}
+
+	private void persistState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		Map<String, Map<String, AlertChannelState>> copiedChannels = new HashMap<>();
+		channelsByProject.forEach((projectId, channels) ->
+			copiedChannels.put(projectId, new LinkedHashMap<>(channels))
+		);
+		Map<String, List<AuditLogState>> copiedAuditLogs = new HashMap<>();
+		auditLogsByProject.forEach((projectId, logs) ->
+			copiedAuditLogs.put(projectId, new ArrayList<>(logs))
+		);
+		stateSnapshotRepository.save(
+			SNAPSHOT_SCOPE,
+			new AlertServiceSnapshot(
+				copiedChannels,
+				copiedAuditLogs,
+				new HashMap<>(lastDispatchAtByProject),
+				new HashMap<>(dispatchBudgetByProject)
+			)
+		);
+	}
+
+	record AlertServiceSnapshot(
+		Map<String, Map<String, AlertChannelState>> channelsByProject,
+		Map<String, List<AuditLogState>> auditLogsByProject,
+		Map<String, Instant> lastDispatchAtByProject,
+		Map<String, DispatchBudgetState> dispatchBudgetByProject
 	) {
 	}
 }

--- a/src/main/java/com/logcopilot/common/auth/BearerTokenValidator.java
+++ b/src/main/java/com/logcopilot/common/auth/BearerTokenValidator.java
@@ -1,9 +1,13 @@
 package com.logcopilot.common.auth;
 
+import com.logcopilot.common.persistence.TokenHashStore;
 import com.logcopilot.common.error.UnauthorizedException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Component
 public class BearerTokenValidator {
@@ -22,6 +26,26 @@ public class BearerTokenValidator {
 		Map.entry("api-token", TokenType.API),
 		Map.entry("token", TokenType.API)
 	);
+	private static final Map<String, String> VERIFIED_TOKEN_TYPES = VERIFIED_TOKENS.entrySet().stream()
+		.collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().name()));
+
+	private final TokenHashStore tokenHashStore;
+
+	public BearerTokenValidator() {
+		this((TokenHashStore) null);
+	}
+
+	@Autowired
+	public BearerTokenValidator(ObjectProvider<TokenHashStore> tokenHashStoreProvider) {
+		this(tokenHashStoreProvider.getIfAvailable());
+	}
+
+	BearerTokenValidator(TokenHashStore tokenHashStore) {
+		this.tokenHashStore = tokenHashStore;
+		if (this.tokenHashStore != null) {
+			this.tokenHashStore.ensureDefaults(VERIFIED_TOKEN_TYPES);
+		}
+	}
 
 	public ValidatedToken validate(String authorization) {
 		if (authorization == null) {
@@ -34,12 +58,32 @@ public class BearerTokenValidator {
 		}
 
 		String token = parts[1];
-		TokenType tokenType = VERIFIED_TOKENS.get(token);
+		TokenType tokenType;
+		try {
+			tokenType = resolveTokenType(token);
+		} catch (RuntimeException exception) {
+			throw new UnauthorizedException("Missing or invalid bearer token");
+		}
 		if (tokenType == null) {
 			throw new UnauthorizedException("Missing or invalid bearer token");
 		}
 
 		return new ValidatedToken(token, tokenType);
+	}
+
+	private TokenType resolveTokenType(String token) {
+		if (tokenHashStore == null) {
+			return VERIFIED_TOKENS.get(token);
+		}
+		Optional<String> tokenType = tokenHashStore.findTokenType(token);
+		if (tokenType.isEmpty()) {
+			return null;
+		}
+		try {
+			return TokenType.valueOf(tokenType.get());
+		} catch (IllegalArgumentException exception) {
+			return null;
+		}
 	}
 
 	public record ValidatedToken(

--- a/src/main/java/com/logcopilot/common/persistence/PersistenceProperties.java
+++ b/src/main/java/com/logcopilot/common/persistence/PersistenceProperties.java
@@ -1,5 +1,6 @@
 package com.logcopilot.common.persistence;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "logcopilot.persistence")
@@ -7,7 +8,19 @@ public class PersistenceProperties {
 
 	private boolean enabled = true;
 	private String sqlitePath = "./data/logcopilot.sqlite";
-	private String encryptionKey = "logcopilot-dev-only-change-me";
+	private String encryptionKey;
+
+	@PostConstruct
+	void validate() {
+		if (!enabled) {
+			return;
+		}
+		if (encryptionKey == null || encryptionKey.isBlank()) {
+			throw new IllegalStateException(
+				"logcopilot.persistence.encryption-key must be configured when persistence is enabled"
+			);
+		}
+	}
 
 	public boolean isEnabled() {
 		return enabled;

--- a/src/main/java/com/logcopilot/common/persistence/PersistenceProperties.java
+++ b/src/main/java/com/logcopilot/common/persistence/PersistenceProperties.java
@@ -1,0 +1,35 @@
+package com.logcopilot.common.persistence;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "logcopilot.persistence")
+public class PersistenceProperties {
+
+	private boolean enabled = true;
+	private String sqlitePath = "./data/logcopilot.sqlite";
+	private String encryptionKey = "logcopilot-dev-only-change-me";
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getSqlitePath() {
+		return sqlitePath;
+	}
+
+	public void setSqlitePath(String sqlitePath) {
+		this.sqlitePath = sqlitePath;
+	}
+
+	public String getEncryptionKey() {
+		return encryptionKey;
+	}
+
+	public void setEncryptionKey(String encryptionKey) {
+		this.encryptionKey = encryptionKey;
+	}
+}

--- a/src/main/java/com/logcopilot/common/persistence/SqlitePersistenceConfiguration.java
+++ b/src/main/java/com/logcopilot/common/persistence/SqlitePersistenceConfiguration.java
@@ -10,6 +10,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.sqlite.SQLiteDataSource;
 
 import javax.sql.DataSource;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -80,10 +82,42 @@ public class SqlitePersistenceConfiguration {
 		if (trimmed.startsWith("jdbc:sqlite:")) {
 			trimmed = trimmed.substring("jdbc:sqlite:".length());
 		}
-		if (trimmed.startsWith(":memory:")) {
+		if (trimmed.startsWith(":memory:") || trimmed.startsWith(":resource:")) {
 			return;
 		}
-		createParentDirectory(trimmed);
+		String filesystemPath = toFilesystemPathForDirectoryPreparation(trimmed);
+		if (filesystemPath == null || filesystemPath.isBlank()) {
+			return;
+		}
+		createParentDirectory(filesystemPath);
+	}
+
+	private String toFilesystemPathForDirectoryPreparation(String rawPath) {
+		int querySeparatorIndex = rawPath.indexOf('?');
+		String withoutQuery = querySeparatorIndex >= 0
+			? rawPath.substring(0, querySeparatorIndex)
+			: rawPath;
+		if (!withoutQuery.startsWith("file:")) {
+			return withoutQuery;
+		}
+		try {
+			URI uri = new URI(withoutQuery);
+			String path = uri.getPath();
+			if (path != null && !path.isBlank()) {
+				return path;
+			}
+			String schemeSpecificPart = uri.getSchemeSpecificPart();
+			if (schemeSpecificPart == null || schemeSpecificPart.isBlank()) {
+				return null;
+			}
+			if (schemeSpecificPart.startsWith("//")) {
+				URI normalized = new URI("file:" + schemeSpecificPart);
+				return normalized.getPath();
+			}
+			return schemeSpecificPart;
+		} catch (URISyntaxException exception) {
+			return null;
+		}
 	}
 
 	private void createParentDirectory(String sqlitePath) {

--- a/src/main/java/com/logcopilot/common/persistence/SqlitePersistenceConfiguration.java
+++ b/src/main/java/com/logcopilot/common/persistence/SqlitePersistenceConfiguration.java
@@ -1,0 +1,101 @@
+package com.logcopilot.common.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.sqlite.SQLiteDataSource;
+
+import javax.sql.DataSource;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Configuration
+@EnableConfigurationProperties(PersistenceProperties.class)
+public class SqlitePersistenceConfiguration {
+
+	@Bean
+	@ConditionalOnProperty(name = "logcopilot.persistence.enabled", havingValue = "true", matchIfMissing = true)
+	public DataSource sqliteDataSource(PersistenceProperties properties) {
+		String jdbcUrl = toJdbcUrl(properties.getSqlitePath());
+		prepareSqliteParentDirectory(properties.getSqlitePath());
+
+		SQLiteDataSource dataSource = new SQLiteDataSource();
+		dataSource.setUrl(jdbcUrl);
+		return dataSource;
+	}
+
+	@Bean
+	@ConditionalOnBean(DataSource.class)
+	public JdbcTemplate jdbcTemplate(DataSource dataSource) {
+		return new JdbcTemplate(dataSource);
+	}
+
+	@Bean
+	@ConditionalOnBean(JdbcTemplate.class)
+	public StateCipher stateCipher(PersistenceProperties properties) {
+		return new StateCipher(properties.getEncryptionKey());
+	}
+
+	@Bean
+	@ConditionalOnBean(JdbcTemplate.class)
+	public StateSnapshotRepository stateSnapshotRepository(
+		JdbcTemplate jdbcTemplate,
+		ObjectMapper objectMapper,
+		StateCipher stateCipher
+	) {
+		return new SqliteStateSnapshotRepository(jdbcTemplate, objectMapper, stateCipher);
+	}
+
+	@Bean
+	@ConditionalOnBean(JdbcTemplate.class)
+	public TokenHashStore tokenHashStore(JdbcTemplate jdbcTemplate) {
+		return new SqliteTokenHashStore(jdbcTemplate);
+	}
+
+	private String toJdbcUrl(String sqlitePath) {
+		if (sqlitePath == null || sqlitePath.isBlank()) {
+			return "jdbc:sqlite:./data/logcopilot.sqlite";
+		}
+		String trimmed = sqlitePath.trim();
+		if (trimmed.startsWith("jdbc:sqlite:")) {
+			return trimmed;
+		}
+		if (trimmed.startsWith(":memory:")) {
+			return "jdbc:sqlite::memory:";
+		}
+		return "jdbc:sqlite:" + trimmed;
+	}
+
+	private void prepareSqliteParentDirectory(String sqlitePath) {
+		if (sqlitePath == null || sqlitePath.isBlank()) {
+			createParentDirectory("./data/logcopilot.sqlite");
+			return;
+		}
+		String trimmed = sqlitePath.trim();
+		if (trimmed.startsWith("jdbc:sqlite:")) {
+			trimmed = trimmed.substring("jdbc:sqlite:".length());
+		}
+		if (trimmed.startsWith(":memory:")) {
+			return;
+		}
+		createParentDirectory(trimmed);
+	}
+
+	private void createParentDirectory(String sqlitePath) {
+		Path path = Paths.get(sqlitePath);
+		Path parent = path.toAbsolutePath().getParent();
+		if (parent == null) {
+			return;
+		}
+		try {
+			Files.createDirectories(parent);
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to prepare SQLite directory: " + parent, exception);
+		}
+	}
+}

--- a/src/main/java/com/logcopilot/common/persistence/SqliteStateSnapshotRepository.java
+++ b/src/main/java/com/logcopilot/common/persistence/SqliteStateSnapshotRepository.java
@@ -1,0 +1,119 @@
+package com.logcopilot.common.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public class SqliteStateSnapshotRepository implements StateSnapshotRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqliteStateSnapshotRepository.class);
+	private static final String TABLE_SQL = """
+		create table if not exists state_snapshots (
+			scope text primary key,
+			payload blob not null,
+			updated_at text not null
+		)
+		""";
+
+	private final JdbcTemplate jdbcTemplate;
+	private final ObjectMapper objectMapper;
+	private final StateCipher stateCipher;
+
+	public SqliteStateSnapshotRepository(
+		JdbcTemplate jdbcTemplate,
+		ObjectMapper objectMapper,
+		StateCipher stateCipher
+	) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.objectMapper = objectMapper;
+		this.stateCipher = stateCipher;
+		this.jdbcTemplate.execute(TABLE_SQL);
+	}
+
+	@Override
+	public void save(String scope, Object snapshot) {
+		if (scope == null || scope.isBlank() || snapshot == null) {
+			return;
+		}
+
+		try {
+			byte[] serialized = objectMapper.writeValueAsBytes(snapshot);
+			byte[] encrypted = stateCipher.encrypt(serialized);
+			jdbcTemplate.update(
+				"""
+					insert into state_snapshots(scope, payload, updated_at)
+					values (?, ?, ?)
+					on conflict(scope) do update set
+						payload = excluded.payload,
+						updated_at = excluded.updated_at
+					""",
+				scope,
+				encrypted,
+				Instant.now().toString()
+			);
+		} catch (Exception exception) {
+			logger.warn("Failed to save state snapshot: scope={}", scope, exception);
+		}
+	}
+
+	@Override
+	public <T> Optional<T> load(String scope, Class<T> type) {
+		if (scope == null || scope.isBlank() || type == null) {
+			return Optional.empty();
+		}
+		byte[] encryptedPayload = readEncryptedPayload(scope);
+		if (encryptedPayload == null) {
+			return Optional.empty();
+		}
+
+		try {
+			byte[] decrypted = stateCipher.decrypt(encryptedPayload);
+			return Optional.of(objectMapper.readValue(decrypted, type));
+		} catch (Exception exception) {
+			return handleLoadFailure(scope, exception);
+		}
+	}
+
+	@Override
+	public <T> Optional<T> load(String scope, TypeReference<T> typeReference) {
+		if (scope == null || scope.isBlank() || typeReference == null) {
+			return Optional.empty();
+		}
+		byte[] encryptedPayload = readEncryptedPayload(scope);
+		if (encryptedPayload == null) {
+			return Optional.empty();
+		}
+
+		try {
+			byte[] decrypted = stateCipher.decrypt(encryptedPayload);
+			return Optional.of(objectMapper.readValue(decrypted, typeReference));
+		} catch (Exception exception) {
+			return handleLoadFailure(scope, exception);
+		}
+	}
+
+	private byte[] readEncryptedPayload(String scope) {
+		try {
+			return jdbcTemplate.query(
+				"select payload from state_snapshots where scope = ?",
+				resultSet -> resultSet.next() ? resultSet.getBytes(1) : null,
+				scope
+			);
+		} catch (DataAccessException exception) {
+			throw new IllegalStateException("Failed to query state snapshot: " + scope, exception);
+		}
+	}
+
+	private <T> Optional<T> handleLoadFailure(String scope, Exception exception) {
+		// Skip unreadable snapshot to keep application startup resilient.
+		// Do not delete row automatically; operators may recover data offline.
+		logger.warn("Failed to load state snapshot: scope={}", scope, exception);
+		return Optional.empty();
+	}
+}

--- a/src/main/java/com/logcopilot/common/persistence/SqliteTokenHashStore.java
+++ b/src/main/java/com/logcopilot/common/persistence/SqliteTokenHashStore.java
@@ -1,0 +1,77 @@
+package com.logcopilot.common.persistence;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Optional;
+
+public class SqliteTokenHashStore implements TokenHashStore {
+
+	private static final String TABLE_SQL = """
+		create table if not exists bearer_token_hashes (
+			token_hash text primary key,
+			token_type text not null,
+			created_at text not null
+		)
+		""";
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public SqliteTokenHashStore(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.jdbcTemplate.execute(TABLE_SQL);
+	}
+
+	@Override
+	public void ensureDefaults(Map<String, String> tokenTypeByPlainToken) {
+		if (tokenTypeByPlainToken == null || tokenTypeByPlainToken.isEmpty()) {
+			return;
+		}
+
+		for (Map.Entry<String, String> entry : tokenTypeByPlainToken.entrySet()) {
+			String plainToken = entry.getKey();
+			String tokenType = entry.getValue();
+			if (plainToken == null || plainToken.isBlank() || tokenType == null || tokenType.isBlank()) {
+				continue;
+			}
+			jdbcTemplate.update(
+				"""
+					insert into bearer_token_hashes(token_hash, token_type, created_at)
+					values (?, ?, ?)
+					on conflict(token_hash) do update set
+						token_type = excluded.token_type
+					""",
+				hash(plainToken),
+				tokenType,
+				Instant.now().toString()
+			);
+		}
+	}
+
+	@Override
+	public Optional<String> findTokenType(String plainToken) {
+		if (plainToken == null || plainToken.isBlank()) {
+			return Optional.empty();
+		}
+		String hashed = hash(plainToken);
+		return jdbcTemplate.query(
+			"select token_type from bearer_token_hashes where token_hash = ?",
+			resultSet -> resultSet.next() ? Optional.of(resultSet.getString(1)) : Optional.empty(),
+			hashed
+		);
+	}
+
+	private String hash(String plainToken) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] bytes = digest.digest(plainToken.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(bytes);
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to hash token", exception);
+		}
+	}
+}

--- a/src/main/java/com/logcopilot/common/persistence/StateCipher.java
+++ b/src/main/java/com/logcopilot/common/persistence/StateCipher.java
@@ -1,0 +1,79 @@
+package com.logcopilot.common.persistence;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+public class StateCipher {
+
+	private static final String ALGORITHM = "AES";
+	private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+	private static final int IV_LENGTH = 12;
+	private static final int TAG_LENGTH_BITS = 128;
+
+	private final SecureRandom secureRandom;
+	private final SecretKeySpec keySpec;
+
+	public StateCipher(String encryptionKey) {
+		if (encryptionKey == null || encryptionKey.isBlank()) {
+			throw new IllegalArgumentException("encryptionKey must not be blank");
+		}
+		this.secureRandom = new SecureRandom();
+		this.keySpec = new SecretKeySpec(deriveKey(encryptionKey), ALGORITHM);
+	}
+
+	public byte[] encrypt(byte[] plainBytes) {
+		if (plainBytes == null) {
+			return new byte[0];
+		}
+		try {
+			byte[] iv = new byte[IV_LENGTH];
+			secureRandom.nextBytes(iv);
+
+			Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+			cipher.init(Cipher.ENCRYPT_MODE, keySpec, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+			byte[] encrypted = cipher.doFinal(plainBytes);
+
+			ByteBuffer buffer = ByteBuffer.allocate(IV_LENGTH + encrypted.length);
+			buffer.put(iv);
+			buffer.put(encrypted);
+			return buffer.array();
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to encrypt state payload", exception);
+		}
+	}
+
+	public byte[] decrypt(byte[] encryptedBytes) {
+		if (encryptedBytes == null || encryptedBytes.length == 0) {
+			return new byte[0];
+		}
+		if (encryptedBytes.length <= IV_LENGTH) {
+			throw new IllegalStateException("Encrypted payload is too short");
+		}
+		try {
+			byte[] iv = Arrays.copyOfRange(encryptedBytes, 0, IV_LENGTH);
+			byte[] encryptedPayload = Arrays.copyOfRange(encryptedBytes, IV_LENGTH, encryptedBytes.length);
+
+			Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+			cipher.init(Cipher.DECRYPT_MODE, keySpec, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+			return cipher.doFinal(encryptedPayload);
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to decrypt state payload", exception);
+		}
+	}
+
+	private byte[] deriveKey(String encryptionKey) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hashed = digest.digest(encryptionKey.getBytes(StandardCharsets.UTF_8));
+			return Arrays.copyOf(hashed, 16);
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to derive encryption key", exception);
+		}
+	}
+}

--- a/src/main/java/com/logcopilot/common/persistence/StateCipher.java
+++ b/src/main/java/com/logcopilot/common/persistence/StateCipher.java
@@ -1,7 +1,9 @@
 package com.logcopilot.common.persistence;
 
 import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -13,18 +15,25 @@ public class StateCipher {
 
 	private static final String ALGORITHM = "AES";
 	private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+	private static final String KDF_ALGORITHM = "PBKDF2WithHmacSHA256";
 	private static final int IV_LENGTH = 12;
+	private static final int SALT_LENGTH = 16;
 	private static final int TAG_LENGTH_BITS = 128;
+	private static final int PBKDF2_ITERATIONS = 120_000;
+	private static final int DERIVED_KEY_LENGTH_BITS = 128;
+	private static final byte[] PAYLOAD_HEADER = "LCP1".getBytes(StandardCharsets.US_ASCII);
 
 	private final SecureRandom secureRandom;
-	private final SecretKeySpec keySpec;
+	private final String encryptionKey;
+	private final SecretKeySpec legacyKeySpec;
 
 	public StateCipher(String encryptionKey) {
 		if (encryptionKey == null || encryptionKey.isBlank()) {
 			throw new IllegalArgumentException("encryptionKey must not be blank");
 		}
 		this.secureRandom = new SecureRandom();
-		this.keySpec = new SecretKeySpec(deriveKey(encryptionKey), ALGORITHM);
+		this.encryptionKey = encryptionKey.trim();
+		this.legacyKeySpec = new SecretKeySpec(deriveLegacyKey(this.encryptionKey), ALGORITHM);
 	}
 
 	public byte[] encrypt(byte[] plainBytes) {
@@ -32,14 +41,19 @@ public class StateCipher {
 			return new byte[0];
 		}
 		try {
+			byte[] salt = new byte[SALT_LENGTH];
+			secureRandom.nextBytes(salt);
 			byte[] iv = new byte[IV_LENGTH];
 			secureRandom.nextBytes(iv);
 
 			Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+			SecretKeySpec keySpec = new SecretKeySpec(deriveKey(encryptionKey, salt), ALGORITHM);
 			cipher.init(Cipher.ENCRYPT_MODE, keySpec, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
 			byte[] encrypted = cipher.doFinal(plainBytes);
 
-			ByteBuffer buffer = ByteBuffer.allocate(IV_LENGTH + encrypted.length);
+			ByteBuffer buffer = ByteBuffer.allocate(PAYLOAD_HEADER.length + SALT_LENGTH + IV_LENGTH + encrypted.length);
+			buffer.put(PAYLOAD_HEADER);
+			buffer.put(salt);
 			buffer.put(iv);
 			buffer.put(encrypted);
 			return buffer.array();
@@ -56,24 +70,74 @@ public class StateCipher {
 			throw new IllegalStateException("Encrypted payload is too short");
 		}
 		try {
-			byte[] iv = Arrays.copyOfRange(encryptedBytes, 0, IV_LENGTH);
-			byte[] encryptedPayload = Arrays.copyOfRange(encryptedBytes, IV_LENGTH, encryptedBytes.length);
-
-			Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-			cipher.init(Cipher.DECRYPT_MODE, keySpec, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
-			return cipher.doFinal(encryptedPayload);
+			if (isVersionedPayload(encryptedBytes)) {
+				return decryptVersionedPayload(encryptedBytes);
+			}
+			return decryptLegacyPayload(encryptedBytes);
 		} catch (Exception exception) {
 			throw new IllegalStateException("Failed to decrypt state payload", exception);
 		}
 	}
 
-	private byte[] deriveKey(String encryptionKey) {
+	private boolean isVersionedPayload(byte[] encryptedBytes) {
+		int minimumLength = PAYLOAD_HEADER.length + SALT_LENGTH + IV_LENGTH + 1;
+		if (encryptedBytes.length < minimumLength) {
+			return false;
+		}
+		for (int index = 0; index < PAYLOAD_HEADER.length; index++) {
+			if (encryptedBytes[index] != PAYLOAD_HEADER[index]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private byte[] decryptVersionedPayload(byte[] encryptedBytes) throws Exception {
+		int offset = PAYLOAD_HEADER.length;
+		byte[] salt = Arrays.copyOfRange(encryptedBytes, offset, offset + SALT_LENGTH);
+		offset += SALT_LENGTH;
+		byte[] iv = Arrays.copyOfRange(encryptedBytes, offset, offset + IV_LENGTH);
+		offset += IV_LENGTH;
+		byte[] encryptedPayload = Arrays.copyOfRange(encryptedBytes, offset, encryptedBytes.length);
+
+		Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+		SecretKeySpec keySpec = new SecretKeySpec(deriveKey(encryptionKey, salt), ALGORITHM);
+		cipher.init(Cipher.DECRYPT_MODE, keySpec, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+		return cipher.doFinal(encryptedPayload);
+	}
+
+	private byte[] decryptLegacyPayload(byte[] encryptedBytes) throws Exception {
+		byte[] iv = Arrays.copyOfRange(encryptedBytes, 0, IV_LENGTH);
+		byte[] encryptedPayload = Arrays.copyOfRange(encryptedBytes, IV_LENGTH, encryptedBytes.length);
+		Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+		cipher.init(Cipher.DECRYPT_MODE, legacyKeySpec, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+		return cipher.doFinal(encryptedPayload);
+	}
+
+	private byte[] deriveKey(String encryptionKey, byte[] salt) {
+		PBEKeySpec spec = new PBEKeySpec(
+			encryptionKey.toCharArray(),
+			salt,
+			PBKDF2_ITERATIONS,
+			DERIVED_KEY_LENGTH_BITS
+		);
+		try {
+			SecretKeyFactory factory = SecretKeyFactory.getInstance(KDF_ALGORITHM);
+			return factory.generateSecret(spec).getEncoded();
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to derive encryption key", exception);
+		} finally {
+			spec.clearPassword();
+		}
+	}
+
+	private byte[] deriveLegacyKey(String encryptionKey) {
 		try {
 			MessageDigest digest = MessageDigest.getInstance("SHA-256");
 			byte[] hashed = digest.digest(encryptionKey.getBytes(StandardCharsets.UTF_8));
 			return Arrays.copyOf(hashed, 16);
 		} catch (Exception exception) {
-			throw new IllegalStateException("Failed to derive encryption key", exception);
+			throw new IllegalStateException("Failed to derive legacy encryption key", exception);
 		}
 	}
 }

--- a/src/main/java/com/logcopilot/common/persistence/StateSnapshotRepository.java
+++ b/src/main/java/com/logcopilot/common/persistence/StateSnapshotRepository.java
@@ -1,0 +1,14 @@
+package com.logcopilot.common.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.Optional;
+
+public interface StateSnapshotRepository {
+
+	void save(String scope, Object snapshot);
+
+	<T> Optional<T> load(String scope, Class<T> type);
+
+	<T> Optional<T> load(String scope, TypeReference<T> typeReference);
+}

--- a/src/main/java/com/logcopilot/common/persistence/TokenHashStore.java
+++ b/src/main/java/com/logcopilot/common/persistence/TokenHashStore.java
@@ -1,0 +1,11 @@
+package com.logcopilot.common.persistence;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface TokenHashStore {
+
+	void ensureDefaults(Map<String, String> tokenTypeByPlainToken);
+
+	Optional<String> findTokenType(String plainToken);
+}

--- a/src/main/java/com/logcopilot/connector/LokiConnectorService.java
+++ b/src/main/java/com/logcopilot/connector/LokiConnectorService.java
@@ -3,9 +3,12 @@ package com.logcopilot.connector;
 import com.logcopilot.common.error.BadGatewayException;
 import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.common.error.ValidationException;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
 import com.logcopilot.project.ProjectService;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.net.URI;
@@ -20,11 +23,28 @@ import java.util.UUID;
 @Service
 public class LokiConnectorService {
 
+	private static final String SNAPSHOT_SCOPE = "loki-connector-service";
+
 	private final ProjectService projectService;
+	private final StateSnapshotRepository stateSnapshotRepository;
 	private final Map<String, LokiConnector> connectorByProjectId = new HashMap<>();
 
 	public LokiConnectorService(ProjectService projectService) {
+		this(projectService, (StateSnapshotRepository) null);
+	}
+
+	@Autowired
+	public LokiConnectorService(
+		ProjectService projectService,
+		ObjectProvider<StateSnapshotRepository> stateSnapshotRepositoryProvider
+	) {
+		this(projectService, stateSnapshotRepositoryProvider.getIfAvailable());
+	}
+
+	LokiConnectorService(ProjectService projectService, StateSnapshotRepository stateSnapshotRepository) {
 		this.projectService = projectService;
+		this.stateSnapshotRepository = stateSnapshotRepository;
+		restoreState();
 	}
 
 	public synchronized UpsertResult upsert(String projectId, LokiConnectorRequest request) {
@@ -47,6 +67,7 @@ public class LokiConnectorService {
 				Instant.now()
 			);
 			connectorByProjectId.put(projectId, created);
+			persistState();
 			return new UpsertResult(true, created);
 		}
 
@@ -60,6 +81,7 @@ public class LokiConnectorService {
 			Instant.now()
 		);
 		connectorByProjectId.put(projectId, updated);
+		persistState();
 		return new UpsertResult(false, updated);
 	}
 
@@ -205,5 +227,31 @@ public class LokiConnectorService {
 		int latencyMs,
 		String message
 	) {
+	}
+
+	private void restoreState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.load(SNAPSHOT_SCOPE, LokiConnectorSnapshot.class)
+			.ifPresent(snapshot -> {
+				connectorByProjectId.clear();
+				if (snapshot.connectorByProjectId() != null) {
+					connectorByProjectId.putAll(snapshot.connectorByProjectId());
+				}
+			});
+	}
+
+	private void persistState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.save(
+			SNAPSHOT_SCOPE,
+			new LokiConnectorSnapshot(new HashMap<>(connectorByProjectId))
+		);
+	}
+
+	record LokiConnectorSnapshot(Map<String, LokiConnector> connectorByProjectId) {
 	}
 }

--- a/src/main/java/com/logcopilot/connector/LokiConnectorService.java
+++ b/src/main/java/com/logcopilot/connector/LokiConnectorService.java
@@ -66,8 +66,7 @@ public class LokiConnectorService {
 				pollIntervalSeconds,
 				Instant.now()
 			);
-			connectorByProjectId.put(projectId, created);
-			persistState();
+			persistUpsertedConnector(projectId, created, null);
 			return new UpsertResult(true, created);
 		}
 
@@ -80,8 +79,7 @@ public class LokiConnectorService {
 			pollIntervalSeconds,
 			Instant.now()
 		);
-		connectorByProjectId.put(projectId, updated);
-		persistState();
+		persistUpsertedConnector(projectId, updated, existing);
 		return new UpsertResult(false, updated);
 	}
 
@@ -250,6 +248,20 @@ public class LokiConnectorService {
 			SNAPSHOT_SCOPE,
 			new LokiConnectorSnapshot(new HashMap<>(connectorByProjectId))
 		);
+	}
+
+	private void persistUpsertedConnector(String projectId, LokiConnector current, LokiConnector previous) {
+		connectorByProjectId.put(projectId, current);
+		try {
+			persistState();
+		} catch (RuntimeException exception) {
+			if (previous == null) {
+				connectorByProjectId.remove(projectId);
+			} else {
+				connectorByProjectId.put(projectId, previous);
+			}
+			throw exception;
+		}
 	}
 
 	record LokiConnectorSnapshot(Map<String, LokiConnector> connectorByProjectId) {

--- a/src/main/java/com/logcopilot/connector/SqliteLokiPullCursorStore.java
+++ b/src/main/java/com/logcopilot/connector/SqliteLokiPullCursorStore.java
@@ -45,18 +45,16 @@ public class SqliteLokiPullCursorStore implements LokiPullCursorStore {
 			return;
 		}
 		long normalizedCursor = Math.max(0L, nextCursor);
-		long current = readCursor(projectId);
-		long committed = Math.max(current, normalizedCursor);
 		jdbcTemplate.update(
 			"""
 				insert into loki_pull_cursors(project_id, cursor_value, updated_at)
 				values (?, ?, ?)
 				on conflict(project_id) do update set
-					cursor_value = excluded.cursor_value,
+					cursor_value = max(loki_pull_cursors.cursor_value, excluded.cursor_value),
 					updated_at = excluded.updated_at
 				""",
 			projectId,
-			committed,
+			normalizedCursor,
 			Instant.now().toString()
 		);
 	}

--- a/src/main/java/com/logcopilot/connector/SqliteLokiPullCursorStore.java
+++ b/src/main/java/com/logcopilot/connector/SqliteLokiPullCursorStore.java
@@ -1,0 +1,63 @@
+package com.logcopilot.connector;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@Primary
+@ConditionalOnBean(JdbcTemplate.class)
+public class SqliteLokiPullCursorStore implements LokiPullCursorStore {
+
+	private static final String TABLE_SQL = """
+		create table if not exists loki_pull_cursors (
+			project_id text primary key,
+			cursor_value integer not null,
+			updated_at text not null
+		)
+		""";
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public SqliteLokiPullCursorStore(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.jdbcTemplate.execute(TABLE_SQL);
+	}
+
+	@Override
+	public synchronized long readCursor(String projectId) {
+		if (projectId == null || projectId.isBlank()) {
+			return 0L;
+		}
+		return jdbcTemplate.query(
+			"select cursor_value from loki_pull_cursors where project_id = ?",
+			resultSet -> resultSet.next() ? resultSet.getLong(1) : 0L,
+			projectId
+		);
+	}
+
+	@Override
+	public synchronized void commit(String projectId, long nextCursor) {
+		if (projectId == null || projectId.isBlank()) {
+			return;
+		}
+		long normalizedCursor = Math.max(0L, nextCursor);
+		long current = readCursor(projectId);
+		long committed = Math.max(current, normalizedCursor);
+		jdbcTemplate.update(
+			"""
+				insert into loki_pull_cursors(project_id, cursor_value, updated_at)
+				values (?, ?, ?)
+				on conflict(project_id) do update set
+					cursor_value = excluded.cursor_value,
+					updated_at = excluded.updated_at
+				""",
+			projectId,
+			committed,
+			Instant.now().toString()
+		);
+	}
+}

--- a/src/main/java/com/logcopilot/incident/IncidentService.java
+++ b/src/main/java/com/logcopilot/incident/IncidentService.java
@@ -3,6 +3,7 @@ package com.logcopilot.incident;
 import com.logcopilot.alert.AlertService;
 import com.logcopilot.common.error.ConflictException;
 import com.logcopilot.common.error.NotFoundException;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
 import com.logcopilot.ingest.domain.CanonicalLogEvent;
 import com.logcopilot.incident.analyzer.IncidentAnalyzer;
 import com.logcopilot.incident.analyzer.IncidentReanalyzeCommand;
@@ -13,6 +14,7 @@ import com.logcopilot.incident.domain.IncidentListResult;
 import com.logcopilot.incident.domain.IncidentStatus;
 import com.logcopilot.incident.domain.IncidentSummary;
 import com.logcopilot.incident.domain.ReanalyzeAcceptedResult;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
@@ -31,24 +33,43 @@ import java.util.UUID;
 @Service
 public class IncidentService {
 
+	private static final String SNAPSHOT_SCOPE = "incident-service";
 	private static final Logger logger = LoggerFactory.getLogger(IncidentService.class);
 	private static final int DEFAULT_LIMIT = 50;
 	private static final int MAX_LIMIT = 200;
 
 	private final IncidentAnalyzer incidentAnalyzer;
 	private final AlertService alertService;
+	private final StateSnapshotRepository stateSnapshotRepository;
 	private final Map<String, IncidentState> incidentsById = new LinkedHashMap<>();
 	private final Map<String, List<String>> incidentIdsByProject = new HashMap<>();
 
 	@Autowired
-	public IncidentService(IncidentAnalyzer incidentAnalyzer, AlertService alertService) {
-		this.incidentAnalyzer = incidentAnalyzer;
-		this.alertService = alertService;
+	public IncidentService(
+		IncidentAnalyzer incidentAnalyzer,
+		AlertService alertService,
+		ObjectProvider<StateSnapshotRepository> stateSnapshotRepositoryProvider
+	) {
+		this(incidentAnalyzer, alertService, stateSnapshotRepositoryProvider.getIfAvailable());
+	}
+
+	IncidentService(IncidentAnalyzer incidentAnalyzer, AlertService alertService) {
+		this(incidentAnalyzer, alertService, (StateSnapshotRepository) null);
 	}
 
 	IncidentService(IncidentAnalyzer incidentAnalyzer) {
+		this(incidentAnalyzer, null, (StateSnapshotRepository) null);
+	}
+
+	IncidentService(
+		IncidentAnalyzer incidentAnalyzer,
+		AlertService alertService,
+		StateSnapshotRepository stateSnapshotRepository
+	) {
 		this.incidentAnalyzer = incidentAnalyzer;
-		this.alertService = null;
+		this.alertService = alertService;
+		this.stateSnapshotRepository = stateSnapshotRepository;
+		restoreState();
 	}
 
 	public void recordIngestedEvents(String projectId, List<CanonicalLogEvent> events) {
@@ -94,6 +115,7 @@ public class IncidentService {
 				incidentsById.put(state.id, state);
 				incidentIdsByProject.computeIfAbsent(projectId, ignored -> new ArrayList<>()).add(state.id);
 			}
+			persistState();
 		}
 
 		for (IncidentState state : createdIncidents) {
@@ -190,6 +212,7 @@ public class IncidentService {
 			))
 		);
 		incidentsById.put(incidentId, updated);
+		persistState();
 		return new ReanalyzeAcceptedResult(true, UUID.randomUUID().toString());
 	}
 
@@ -340,7 +363,7 @@ public class IncidentService {
 	private record TimestampRange(Instant firstSeen, Instant lastSeen) {
 	}
 
-	private record IncidentState(
+	record IncidentState(
 		String id,
 		String projectId,
 		IncidentStatus status,
@@ -350,6 +373,46 @@ public class IncidentService {
 		Instant firstSeen,
 		Instant lastSeen,
 		AnalysisReport report
+	) {
+	}
+
+	private void restoreState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.load(SNAPSHOT_SCOPE, IncidentSnapshot.class)
+			.ifPresent(snapshot -> {
+				incidentsById.clear();
+				incidentIdsByProject.clear();
+				if (snapshot.incidentsById() != null) {
+					incidentsById.putAll(snapshot.incidentsById());
+				}
+				if (snapshot.incidentIdsByProject() != null) {
+					snapshot.incidentIdsByProject().forEach((projectId, incidentIds) -> incidentIdsByProject.put(
+						projectId,
+						incidentIds == null ? new ArrayList<>() : new ArrayList<>(incidentIds)
+					));
+				}
+			});
+	}
+
+	private void persistState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		Map<String, List<String>> copiedIncidentIdsByProject = new HashMap<>();
+		incidentIdsByProject.forEach((projectId, incidentIds) ->
+			copiedIncidentIdsByProject.put(projectId, new ArrayList<>(incidentIds))
+		);
+		stateSnapshotRepository.save(
+			SNAPSHOT_SCOPE,
+			new IncidentSnapshot(new LinkedHashMap<>(incidentsById), copiedIncidentIdsByProject)
+		);
+	}
+
+	record IncidentSnapshot(
+		Map<String, IncidentState> incidentsById,
+		Map<String, List<String>> incidentIdsByProject
 	) {
 	}
 }

--- a/src/main/java/com/logcopilot/llm/LlmAccountService.java
+++ b/src/main/java/com/logcopilot/llm/LlmAccountService.java
@@ -4,7 +4,9 @@ import com.logcopilot.common.error.BadRequestException;
 import com.logcopilot.common.error.ConflictException;
 import com.logcopilot.common.error.NotFoundException;
 import com.logcopilot.common.error.ValidationException;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
 import com.logcopilot.project.ProjectService;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -24,23 +26,45 @@ import java.util.UUID;
 @Service
 public class LlmAccountService {
 
+	private static final String SNAPSHOT_SCOPE = "llm-account-service";
+
 	private final ProjectService projectService;
 	private final LlmOAuthProperties oauthProperties;
 	private final Clock clock;
+	private final StateSnapshotRepository stateSnapshotRepository;
 	private final Map<String, LinkedHashMap<String, AccountState>> accountsByProject = new HashMap<>();
 	private final Map<String, Map<String, String>> apiKeyAccountIdByProjectProvider = new HashMap<>();
 	private final Map<String, Map<String, String>> oauthAccountIdByProjectProvider = new HashMap<>();
 	private final Map<String, OAuthState> oauthStateByValue = new HashMap<>();
 
-	@Autowired
 	public LlmAccountService(ProjectService projectService, LlmOAuthProperties oauthProperties) {
-		this(projectService, oauthProperties, Clock.systemUTC());
+		this(projectService, oauthProperties, Clock.systemUTC(), null);
 	}
 
 	LlmAccountService(ProjectService projectService, LlmOAuthProperties oauthProperties, Clock clock) {
+		this(projectService, oauthProperties, clock, null);
+	}
+
+	@Autowired
+	public LlmAccountService(
+		ProjectService projectService,
+		LlmOAuthProperties oauthProperties,
+		ObjectProvider<StateSnapshotRepository> stateSnapshotRepositoryProvider
+	) {
+		this(projectService, oauthProperties, Clock.systemUTC(), stateSnapshotRepositoryProvider.getIfAvailable());
+	}
+
+	LlmAccountService(
+		ProjectService projectService,
+		LlmOAuthProperties oauthProperties,
+		Clock clock,
+		StateSnapshotRepository stateSnapshotRepository
+	) {
 		this.projectService = projectService;
 		this.oauthProperties = oauthProperties;
 		this.clock = clock;
+		this.stateSnapshotRepository = stateSnapshotRepository;
+		restoreState();
 	}
 
 	public synchronized UpsertResult upsertApiKey(String projectId, ApiKeyUpsertCommand command) {
@@ -80,6 +104,7 @@ public class LlmAccountService {
 			);
 			accounts.put(accountId, created);
 			byProvider.put(provider, accountId);
+			persistState();
 			return new UpsertResult(true, toLlmAccount(created));
 		}
 
@@ -100,6 +125,7 @@ public class LlmAccountService {
 			command.apiKey()
 		);
 		accounts.put(existingId, updated);
+		persistState();
 		return new UpsertResult(false, toLlmAccount(updated));
 	}
 
@@ -112,6 +138,7 @@ public class LlmAccountService {
 		String authUrl = buildAuthorizationUrl(projectId, provider, state);
 		enforceOAuthStateCapacity();
 		oauthStateByValue.put(state, new OAuthState(projectId, provider, Instant.now(clock)));
+		persistState();
 		return new OAuthStartResult(authUrl, state);
 	}
 
@@ -135,14 +162,17 @@ public class LlmAccountService {
 		}
 		if (isExpired(started, now)) {
 			oauthStateByValue.remove(state);
+			persistState();
 			throw new ConflictException("Invalid or expired oauth state");
 		}
 		if (!started.projectId().equals(projectId) || !started.provider().equals(provider)) {
 			oauthStateByValue.remove(state);
+			persistState();
 			throw new ConflictException("Invalid or expired oauth state");
 		}
 		oauthStateByValue.remove(state);
 		if (hasProviderError(providerError)) {
+			persistState();
 			throw new BadRequestException(providerErrorMessage(providerError, providerErrorDescription));
 		}
 		validateCode(code);
@@ -158,6 +188,7 @@ public class LlmAccountService {
 
 		String existingId = byProvider.get(provider);
 		if (existingId != null && accounts.containsKey(existingId)) {
+			persistState();
 			return new OAuthCallbackResult(true, existingId);
 		}
 
@@ -175,6 +206,7 @@ public class LlmAccountService {
 		);
 		accounts.put(accountId, created);
 		byProvider.put(provider, accountId);
+		persistState();
 		return new OAuthCallbackResult(true, accountId);
 	}
 
@@ -204,6 +236,7 @@ public class LlmAccountService {
 			if (byProvider != null) {
 				byProvider.remove(removed.provider());
 			}
+			persistState();
 			return;
 		}
 
@@ -213,6 +246,7 @@ public class LlmAccountService {
 				byProvider.remove(removed.provider());
 			}
 		}
+		persistState();
 	}
 
 	private void requireProject(String projectId) {
@@ -448,7 +482,7 @@ public class LlmAccountService {
 	) {
 	}
 
-	private record AccountState(
+	record AccountState(
 		String id,
 		String provider,
 		String authType,
@@ -461,10 +495,84 @@ public class LlmAccountService {
 	) {
 	}
 
-	private record OAuthState(
+	record OAuthState(
 		String projectId,
 		String provider,
 		Instant createdAt
+	) {
+	}
+
+	private void restoreState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.load(SNAPSHOT_SCOPE, LlmAccountSnapshot.class)
+			.ifPresent(snapshot -> {
+				accountsByProject.clear();
+				apiKeyAccountIdByProjectProvider.clear();
+				oauthAccountIdByProjectProvider.clear();
+				oauthStateByValue.clear();
+
+				if (snapshot.accountsByProject() != null) {
+					snapshot.accountsByProject().forEach((projectId, accounts) -> accountsByProject.put(
+						projectId,
+						accounts == null ? new LinkedHashMap<>() : new LinkedHashMap<>(accounts)
+					));
+				}
+				if (snapshot.apiKeyAccountIdByProjectProvider() != null) {
+					snapshot.apiKeyAccountIdByProjectProvider().forEach((projectId, mapping) ->
+						apiKeyAccountIdByProjectProvider.put(
+							projectId,
+							mapping == null ? new HashMap<>() : new HashMap<>(mapping)
+						)
+					);
+				}
+				if (snapshot.oauthAccountIdByProjectProvider() != null) {
+					snapshot.oauthAccountIdByProjectProvider().forEach((projectId, mapping) ->
+						oauthAccountIdByProjectProvider.put(
+							projectId,
+							mapping == null ? new HashMap<>() : new HashMap<>(mapping)
+						)
+					);
+				}
+				if (snapshot.oauthStateByValue() != null) {
+					oauthStateByValue.putAll(snapshot.oauthStateByValue());
+				}
+			});
+	}
+
+	private void persistState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		Map<String, LinkedHashMap<String, AccountState>> copiedAccounts = new HashMap<>();
+		accountsByProject.forEach((projectId, accounts) ->
+			copiedAccounts.put(projectId, new LinkedHashMap<>(accounts))
+		);
+		Map<String, Map<String, String>> copiedApiKeyMapping = new HashMap<>();
+		apiKeyAccountIdByProjectProvider.forEach((projectId, mapping) ->
+			copiedApiKeyMapping.put(projectId, new HashMap<>(mapping))
+		);
+		Map<String, Map<String, String>> copiedOauthMapping = new HashMap<>();
+		oauthAccountIdByProjectProvider.forEach((projectId, mapping) ->
+			copiedOauthMapping.put(projectId, new HashMap<>(mapping))
+		);
+		stateSnapshotRepository.save(
+			SNAPSHOT_SCOPE,
+			new LlmAccountSnapshot(
+				copiedAccounts,
+				copiedApiKeyMapping,
+				copiedOauthMapping,
+				new HashMap<>(oauthStateByValue)
+			)
+		);
+	}
+
+	record LlmAccountSnapshot(
+		Map<String, LinkedHashMap<String, AccountState>> accountsByProject,
+		Map<String, Map<String, String>> apiKeyAccountIdByProjectProvider,
+		Map<String, Map<String, String>> oauthAccountIdByProjectProvider,
+		Map<String, OAuthState> oauthStateByValue
 	) {
 	}
 }

--- a/src/main/java/com/logcopilot/policy/PolicyService.java
+++ b/src/main/java/com/logcopilot/policy/PolicyService.java
@@ -1,8 +1,11 @@
 package com.logcopilot.policy;
 
 import com.logcopilot.common.error.BadRequestException;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
 import com.logcopilot.common.security.SensitiveDataSanitizer;
 import com.logcopilot.project.ProjectService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -17,6 +20,7 @@ import java.util.regex.PatternSyntaxException;
 @Service
 public class PolicyService {
 
+	private static final String SNAPSHOT_SCOPE = "policy-service";
 	private static final int MAX_REDACTION_RULES = 200;
 	private static final int MAX_REGEX_PATTERN_LENGTH = 512;
 	private static final Pattern NESTED_QUANTIFIER_PATTERN =
@@ -25,11 +29,26 @@ public class PolicyService {
 		);
 
 	private final ProjectService projectService;
+	private final StateSnapshotRepository stateSnapshotRepository;
 	private final Map<String, ExportPolicyState> exportPolicyByProject = new HashMap<>();
 	private final Map<String, RedactionPolicyState> redactionPolicyByProject = new HashMap<>();
 
 	public PolicyService(ProjectService projectService) {
+		this(projectService, (StateSnapshotRepository) null);
+	}
+
+	@Autowired
+	public PolicyService(
+		ProjectService projectService,
+		ObjectProvider<StateSnapshotRepository> stateSnapshotRepositoryProvider
+	) {
+		this(projectService, stateSnapshotRepositoryProvider.getIfAvailable());
+	}
+
+	PolicyService(ProjectService projectService, StateSnapshotRepository stateSnapshotRepository) {
 		this.projectService = projectService;
+		this.stateSnapshotRepository = stateSnapshotRepository;
+		restoreState();
 	}
 
 	public synchronized ExportPolicyResult updateExportPolicy(String projectId, ExportPolicyCommand command) {
@@ -41,6 +60,7 @@ public class PolicyService {
 		String level = validateExportLevel(command.level());
 		ExportPolicyState updated = new ExportPolicyState(level, Instant.now());
 		exportPolicyByProject.put(projectId, updated);
+		persistState();
 		return new ExportPolicyResult(updated.level(), updated.updatedAt());
 	}
 
@@ -57,6 +77,7 @@ public class PolicyService {
 		List<RedactionRuleState> normalizedRules = normalizeAndValidateRules(command.rules());
 		RedactionPolicyState updated = new RedactionPolicyState(enabled, normalizedRules, Instant.now());
 		redactionPolicyByProject.put(projectId, updated);
+		persistState();
 		return new RedactionPolicyResult(updated.enabled(), updated.rules().size(), updated.updatedAt());
 	}
 
@@ -213,23 +234,59 @@ public class PolicyService {
 	) {
 	}
 
-	private record ExportPolicyState(
+	record ExportPolicyState(
 		String level,
 		Instant updatedAt
 	) {
 	}
 
-	private record RedactionPolicyState(
+	record RedactionPolicyState(
 		boolean enabled,
 		List<RedactionRuleState> rules,
 		Instant updatedAt
 	) {
 	}
 
-	private record RedactionRuleState(
+	record RedactionRuleState(
 		String name,
 		String pattern,
 		String replaceWith
+	) {
+	}
+
+	private void restoreState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.load(SNAPSHOT_SCOPE, PolicySnapshot.class)
+			.ifPresent(snapshot -> {
+				exportPolicyByProject.clear();
+				redactionPolicyByProject.clear();
+				if (snapshot.exportPolicyByProject() != null) {
+					exportPolicyByProject.putAll(snapshot.exportPolicyByProject());
+				}
+				if (snapshot.redactionPolicyByProject() != null) {
+					redactionPolicyByProject.putAll(snapshot.redactionPolicyByProject());
+				}
+			});
+	}
+
+	private void persistState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.save(
+			SNAPSHOT_SCOPE,
+			new PolicySnapshot(
+				new HashMap<>(exportPolicyByProject),
+				new HashMap<>(redactionPolicyByProject)
+			)
+		);
+	}
+
+	record PolicySnapshot(
+		Map<String, ExportPolicyState> exportPolicyByProject,
+		Map<String, RedactionPolicyState> redactionPolicyByProject
 	) {
 	}
 }

--- a/src/main/java/com/logcopilot/project/ProjectService.java
+++ b/src/main/java/com/logcopilot/project/ProjectService.java
@@ -2,6 +2,9 @@ package com.logcopilot.project;
 
 import com.logcopilot.common.error.BadRequestException;
 import com.logcopilot.common.error.ConflictException;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -15,8 +18,25 @@ import java.util.UUID;
 @Service
 public class ProjectService {
 
+	private static final String SNAPSHOT_SCOPE = "project-service";
+
+	private final StateSnapshotRepository stateSnapshotRepository;
 	private final Map<String, ProjectDto> projectsById = new LinkedHashMap<>();
 	private final Map<String, String> projectIdByNameKey = new HashMap<>();
+
+	public ProjectService() {
+		this((StateSnapshotRepository) null);
+	}
+
+	@Autowired
+	public ProjectService(ObjectProvider<StateSnapshotRepository> stateSnapshotRepositoryProvider) {
+		this(stateSnapshotRepositoryProvider.getIfAvailable());
+	}
+
+	ProjectService(StateSnapshotRepository stateSnapshotRepository) {
+		this.stateSnapshotRepository = stateSnapshotRepository;
+		restoreState();
+	}
 
 	public synchronized ProjectDto create(String name, String environment) {
 		String normalizedName = validateName(name);
@@ -36,6 +56,7 @@ public class ProjectService {
 
 		projectsById.put(project.id(), project);
 		projectIdByNameKey.put(nameKey, project.id());
+		persistState();
 		return project;
 	}
 
@@ -69,5 +90,41 @@ public class ProjectService {
 			case "prod", "staging", "dev" -> environment;
 			default -> throw new BadRequestException("Environment must be one of: prod, staging, dev");
 		};
+	}
+
+	private void restoreState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.load(SNAPSHOT_SCOPE, ProjectSnapshot.class)
+			.ifPresent(snapshot -> {
+				projectsById.clear();
+				projectIdByNameKey.clear();
+				if (snapshot.projectsById() != null) {
+					projectsById.putAll(snapshot.projectsById());
+				}
+				if (snapshot.projectIdByNameKey() != null) {
+					projectIdByNameKey.putAll(snapshot.projectIdByNameKey());
+				}
+			});
+	}
+
+	private void persistState() {
+		if (stateSnapshotRepository == null) {
+			return;
+		}
+		stateSnapshotRepository.save(
+			SNAPSHOT_SCOPE,
+			new ProjectSnapshot(
+				new LinkedHashMap<>(projectsById),
+				new HashMap<>(projectIdByNameKey)
+			)
+		);
+	}
+
+	record ProjectSnapshot(
+		Map<String, ProjectDto> projectsById,
+		Map<String, String> projectIdByNameKey
+	) {
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,6 @@ logcopilot.alert.storm.quiet-hours.end=07:00
 logcopilot.alert.storm.quiet-hours.zone=UTC
 logcopilot.alert.storm.max-scopes=10000
 logcopilot.alert.storm.scope-retention=PT24H
+logcopilot.persistence.enabled=true
+logcopilot.persistence.sqlite.path=./data/logcopilot.sqlite
+logcopilot.persistence.encryption-key=logcopilot-dev-only-change-me

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ logcopilot.alert.storm.quiet-hours.zone=UTC
 logcopilot.alert.storm.max-scopes=10000
 logcopilot.alert.storm.scope-retention=PT24H
 logcopilot.persistence.enabled=true
-logcopilot.persistence.sqlite.path=./data/logcopilot.sqlite
-logcopilot.persistence.encryption-key=logcopilot-dev-only-change-me
+logcopilot.persistence.sqlite-path=./data/logcopilot.sqlite
+# logcopilot.persistence.encryption-key 는 코드에 고정하지 않고 환경 변수(예: LOGCOPILOT_PERSISTENCE_ENCRYPTION_KEY)로 주입한다.

--- a/src/test/java/com/logcopilot/alert/AuditPersistenceTest.java
+++ b/src/test/java/com/logcopilot/alert/AuditPersistenceTest.java
@@ -1,0 +1,115 @@
+package com.logcopilot.alert;
+
+import com.logcopilot.LogcopilotApplication;
+import com.logcopilot.project.ProjectDto;
+import com.logcopilot.project.ProjectService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuditPersistenceTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void keepsAuditLogsAppendOnlyAcrossRestart() {
+		Path dbPath = tempDir.resolve("logcopilot-t21-audit.sqlite");
+		deleteIfExists(dbPath);
+		String projectId;
+		List<String> firstLogIds;
+
+		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+			ProjectService projectService = context.getBean(ProjectService.class);
+			AlertService alertService = context.getBean(AlertService.class);
+
+			ProjectDto project = projectService.create("t21-audit-project-" + UUID.randomUUID(), "prod");
+			projectId = project.id();
+
+			alertService.configureSlack(
+				projectId,
+				"actor-a",
+				new AlertService.ConfigureSlackCommand(
+					"https://hooks.slack.com/services/T000/B000/AAA",
+					"#ops",
+					0.45
+				)
+			);
+			alertService.configureEmail(
+				projectId,
+				"actor-b",
+				new AlertService.ConfigureEmailCommand(
+					"alerts@example.com",
+					List.of("oncall@example.com"),
+					new AlertService.SmtpCommand("smtp.example.com", 587, "mailer", "smtp-secret", true),
+					0.55
+				)
+			);
+
+			firstLogIds = alertService.listAuditLogs(projectId, new AlertService.AuditLogQuery(null, null, null, 50))
+				.data()
+				.stream()
+				.map(AlertService.AuditLog::id)
+				.toList();
+			assertThat(firstLogIds).hasSize(2);
+		}
+
+		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+			AlertService alertService = context.getBean(AlertService.class);
+			List<AlertService.AuditLog> restored = alertService.listAuditLogs(
+				projectId,
+				new AlertService.AuditLogQuery(null, null, null, 50)
+			).data();
+
+			assertThat(restored).hasSize(2);
+			assertThat(restored.stream().map(AlertService.AuditLog::id).toList())
+				.containsExactlyInAnyOrderElementsOf(firstLogIds);
+
+			alertService.configureSlack(
+				projectId,
+				"actor-c",
+				new AlertService.ConfigureSlackCommand(
+					"https://hooks.slack.com/services/T000/B000/BBB",
+					"#platform",
+					0.65
+				)
+			);
+
+			List<AlertService.AuditLog> afterAppend = alertService.listAuditLogs(
+				projectId,
+				new AlertService.AuditLogQuery(null, null, null, 50)
+			).data();
+
+			assertThat(afterAppend).hasSize(3);
+			assertThat(afterAppend.stream().map(AlertService.AuditLog::id).toList())
+				.containsAll(firstLogIds);
+		}
+	}
+
+	private ConfigurableApplicationContext startContext(Path dbPath) {
+		return new SpringApplicationBuilder(LogcopilotApplication.class)
+			.run(
+				"--server.port=0",
+				"--spring.task.scheduling.enabled=false",
+				"--logcopilot.persistence.enabled=true",
+				"--logcopilot.persistence.sqlite.path=" + dbPath.toAbsolutePath(),
+				"--logcopilot.persistence.encryption-key=t21-test-encryption-key"
+			);
+	}
+
+	private void deleteIfExists(Path dbPath) {
+		try {
+			Files.deleteIfExists(dbPath);
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to clean sqlite file: " + dbPath, exception);
+		}
+	}
+}

--- a/src/test/java/com/logcopilot/alert/AuditPersistenceTest.java
+++ b/src/test/java/com/logcopilot/alert/AuditPersistenceTest.java
@@ -24,10 +24,11 @@ class AuditPersistenceTest {
 	void keepsAuditLogsAppendOnlyAcrossRestart() {
 		Path dbPath = tempDir.resolve("logcopilot-t21-audit.sqlite");
 		deleteIfExists(dbPath);
+		String encryptionSecret = "ephemeral-" + UUID.randomUUID();
 		String projectId;
 		List<String> firstLogIds;
 
-		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+		try (ConfigurableApplicationContext context = startContext(dbPath, encryptionSecret)) {
 			ProjectService projectService = context.getBean(ProjectService.class);
 			AlertService alertService = context.getBean(AlertService.class);
 
@@ -62,7 +63,7 @@ class AuditPersistenceTest {
 			assertThat(firstLogIds).hasSize(2);
 		}
 
-		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+		try (ConfigurableApplicationContext context = startContext(dbPath, encryptionSecret)) {
 			AlertService alertService = context.getBean(AlertService.class);
 			List<AlertService.AuditLog> restored = alertService.listAuditLogs(
 				projectId,
@@ -94,14 +95,14 @@ class AuditPersistenceTest {
 		}
 	}
 
-	private ConfigurableApplicationContext startContext(Path dbPath) {
+	private ConfigurableApplicationContext startContext(Path dbPath, String encryptionSecret) {
 		return new SpringApplicationBuilder(LogcopilotApplication.class)
 			.run(
 				"--server.port=0",
 				"--spring.task.scheduling.enabled=false",
 				"--logcopilot.persistence.enabled=true",
-				"--logcopilot.persistence.sqlite.path=" + dbPath.toAbsolutePath(),
-				"--logcopilot.persistence.encryption-key=t21-test-encryption-key"
+				"--logcopilot.persistence.sqlite-path=" + dbPath.toAbsolutePath(),
+				"--logcopilot.persistence.encryption-key=" + encryptionSecret
 			);
 	}
 

--- a/src/test/java/com/logcopilot/common/auth/BearerTokenValidatorTest.java
+++ b/src/test/java/com/logcopilot/common/auth/BearerTokenValidatorTest.java
@@ -1,8 +1,12 @@
 package com.logcopilot.common.auth;
 
 import com.logcopilot.common.error.UnauthorizedException;
+import com.logcopilot.common.persistence.TokenHashStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -65,6 +69,50 @@ class BearerTokenValidatorTest {
 	@DisplayName("BearerTokenValidator는 등록되지 않은 토큰이면 예외를 던진다")
 	void throwsWhenTokenIsNotRegistered() {
 		assertThatThrownBy(() -> validator.validate("Bearer unknown-token"))
+			.isInstanceOf(UnauthorizedException.class)
+			.hasMessage("Missing or invalid bearer token");
+	}
+
+	@Test
+	@DisplayName("BearerTokenValidator는 hash 저장소 기반 토큰 검증을 지원한다")
+	void validatesUsingHashBackedTokenStore() {
+		TokenHashStore tokenHashStore = new TokenHashStore() {
+			@Override
+			public void ensureDefaults(Map<String, String> tokenTypeByPlainToken) {
+			}
+
+			@Override
+			public Optional<String> findTokenType(String plainToken) {
+				if ("ingest-token".equals(plainToken)) {
+					return Optional.of("INGEST");
+				}
+				return Optional.empty();
+			}
+		};
+		BearerTokenValidator hashBackedValidator = new BearerTokenValidator(tokenHashStore);
+
+		BearerTokenValidator.ValidatedToken token = hashBackedValidator.validate("Bearer ingest-token");
+
+		assertThat(token.value()).isEqualTo("ingest-token");
+		assertThat(token.type()).isEqualTo(BearerTokenValidator.TokenType.INGEST);
+	}
+
+	@Test
+	@DisplayName("BearerTokenValidator는 hash 저장소 오류가 나면 UnauthorizedException을 던진다")
+	void throwsUnauthorizedWhenHashStoreFails() {
+		TokenHashStore tokenHashStore = new TokenHashStore() {
+			@Override
+			public void ensureDefaults(Map<String, String> tokenTypeByPlainToken) {
+			}
+
+			@Override
+			public Optional<String> findTokenType(String plainToken) {
+				throw new IllegalStateException("db unavailable");
+			}
+		};
+		BearerTokenValidator hashBackedValidator = new BearerTokenValidator(tokenHashStore);
+
+		assertThatThrownBy(() -> hashBackedValidator.validate("Bearer ingest-token"))
 			.isInstanceOf(UnauthorizedException.class)
 			.hasMessage("Missing or invalid bearer token");
 	}

--- a/src/test/java/com/logcopilot/common/persistence/PersistencePropertiesTest.java
+++ b/src/test/java/com/logcopilot/common/persistence/PersistencePropertiesTest.java
@@ -1,0 +1,29 @@
+package com.logcopilot.common.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PersistencePropertiesTest {
+
+	@Test
+	void failsValidationWhenPersistenceEnabledAndKeyMissing() {
+		PersistenceProperties properties = new PersistenceProperties();
+		properties.setEnabled(true);
+		properties.setEncryptionKey(" ");
+
+		assertThatThrownBy(properties::validate)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("logcopilot.persistence.encryption-key must be configured when persistence is enabled");
+	}
+
+	@Test
+	void allowsMissingKeyWhenPersistenceDisabled() {
+		PersistenceProperties properties = new PersistenceProperties();
+		properties.setEnabled(false);
+		properties.setEncryptionKey(null);
+
+		assertThatCode(properties::validate).doesNotThrowAnyException();
+	}
+}

--- a/src/test/java/com/logcopilot/common/persistence/StateCipherTest.java
+++ b/src/test/java/com/logcopilot/common/persistence/StateCipherTest.java
@@ -1,0 +1,64 @@
+package com.logcopilot.common.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StateCipherTest {
+
+	@Test
+	void encryptsAndDecryptsWithVersionedPayload() {
+		StateCipher cipher = new StateCipher("state-cipher-test-secret");
+		byte[] plain = "sensitive-state-payload".getBytes(StandardCharsets.UTF_8);
+
+		byte[] encrypted = cipher.encrypt(plain);
+
+		assertThat(encrypted.length).isGreaterThan(plain.length);
+		assertThat(new String(encrypted, StandardCharsets.UTF_8)).doesNotContain("sensitive-state-payload");
+		assertThat(cipher.decrypt(encrypted)).containsExactly(plain);
+	}
+
+	@Test
+	void decryptsLegacyPayloadForBackwardCompatibility() {
+		String secret = "state-cipher-legacy-secret";
+		byte[] plain = "legacy-payload".getBytes(StandardCharsets.UTF_8);
+		StateCipher cipher = new StateCipher(secret);
+
+		byte[] legacyEncrypted = encryptLegacy(secret, plain);
+
+		assertThat(cipher.decrypt(legacyEncrypted)).containsExactly(plain);
+	}
+
+	private byte[] encryptLegacy(String secret, byte[] plain) {
+		try {
+			byte[] iv = new byte[12];
+			new SecureRandom().nextBytes(iv);
+			byte[] hashed = MessageDigest.getInstance("SHA-256")
+				.digest(secret.getBytes(StandardCharsets.UTF_8));
+			byte[] legacyKey = Arrays.copyOf(hashed, 16);
+
+			Cipher legacyCipher = Cipher.getInstance("AES/GCM/NoPadding");
+			legacyCipher.init(
+				Cipher.ENCRYPT_MODE,
+				new SecretKeySpec(legacyKey, "AES"),
+				new GCMParameterSpec(128, iv)
+			);
+			byte[] encrypted = legacyCipher.doFinal(plain);
+			ByteBuffer buffer = ByteBuffer.allocate(iv.length + encrypted.length);
+			buffer.put(iv);
+			buffer.put(encrypted);
+			return buffer.array();
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to build legacy payload for test", exception);
+		}
+	}
+}

--- a/src/test/java/com/logcopilot/connector/LokiConnectorServiceTest.java
+++ b/src/test/java/com/logcopilot/connector/LokiConnectorServiceTest.java
@@ -1,0 +1,93 @@
+package com.logcopilot.connector;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.logcopilot.common.persistence.StateSnapshotRepository;
+import com.logcopilot.project.ProjectService;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LokiConnectorServiceTest {
+
+	private final ProjectService projectService = new ProjectService();
+
+	@Test
+	void rollsBackCreateWhenPersistenceFails() {
+		LokiConnectorService service = new LokiConnectorService(projectService, new FlakySnapshotRepository(1));
+		String projectId = createProjectId();
+
+		assertThatThrownBy(() -> service.upsert(projectId, sampleRequest("{service=\"api\"}")))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("forced persistence failure");
+
+		assertThat(service.findByProjectId(projectId)).isEmpty();
+	}
+
+	@Test
+	void rollsBackUpdateWhenPersistenceFails() {
+		LokiConnectorService service = new LokiConnectorService(projectService, new FlakySnapshotRepository(2));
+		String projectId = createProjectId();
+
+		LokiConnectorService.UpsertResult created = service.upsert(projectId, sampleRequest("{service=\"api\"}"));
+		assertThat(created.created()).isTrue();
+
+		assertThatThrownBy(() -> service.upsert(projectId, sampleRequest("{service=\"worker\"}")))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("forced persistence failure");
+
+		LokiConnectorService.LokiConnector restored = service.findByProjectId(projectId).orElseThrow();
+		assertThat(restored.query()).isEqualTo("{service=\"api\"}");
+	}
+
+	private String createProjectId() {
+		return projectService.create("loki-service-test-" + UUID.randomUUID(), "prod").id();
+	}
+
+	private LokiConnectorService.LokiConnectorRequest sampleRequest(String query) {
+		return new LokiConnectorService.LokiConnectorRequest(
+			"https://loki.example.com",
+			"tenant-a",
+			new LokiConnectorService.AuthRequest("none", null, null, null),
+			query,
+			30
+		);
+	}
+
+	private static final class FlakySnapshotRepository implements StateSnapshotRepository {
+
+		private final int failOnSaveCount;
+		private final Map<String, Object> snapshots = new HashMap<>();
+		private int saveCount;
+
+		private FlakySnapshotRepository(int failOnSaveCount) {
+			this.failOnSaveCount = failOnSaveCount;
+		}
+
+		@Override
+		public void save(String scope, Object snapshot) {
+			saveCount++;
+			if (saveCount == failOnSaveCount) {
+				throw new IllegalStateException("forced persistence failure");
+			}
+			snapshots.put(scope, snapshot);
+		}
+
+		@Override
+		public <T> Optional<T> load(String scope, Class<T> type) {
+			return Optional.ofNullable(type.cast(snapshots.get(scope)));
+		}
+
+		@Override
+		public <T> Optional<T> load(String scope, TypeReference<T> typeReference) {
+			@SuppressWarnings("unchecked")
+			T snapshot = (T) snapshots.get(scope);
+			return Optional.ofNullable(snapshot);
+		}
+	}
+}

--- a/src/test/java/com/logcopilot/connector/SqliteLokiPullCursorStoreTest.java
+++ b/src/test/java/com/logcopilot/connector/SqliteLokiPullCursorStoreTest.java
@@ -1,0 +1,42 @@
+package com.logcopilot.connector;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.sqlite.SQLiteDataSource;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqliteLokiPullCursorStoreTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void keepsCursorMonotonicWithAtomicUpsert() {
+		SqliteLokiPullCursorStore store = new SqliteLokiPullCursorStore(jdbcTemplate(tempDir.resolve("cursor-monotonic.sqlite")));
+
+		store.commit("project-1", 10L);
+		store.commit("project-1", 7L);
+		store.commit("project-1", 21L);
+
+		assertThat(store.readCursor("project-1")).isEqualTo(21L);
+	}
+
+	@Test
+	void normalizesNegativeCursorBeforeCommit() {
+		SqliteLokiPullCursorStore store = new SqliteLokiPullCursorStore(jdbcTemplate(tempDir.resolve("cursor-negative.sqlite")));
+
+		store.commit("project-1", -1L);
+
+		assertThat(store.readCursor("project-1")).isZero();
+	}
+
+	private JdbcTemplate jdbcTemplate(Path dbPath) {
+		SQLiteDataSource dataSource = new SQLiteDataSource();
+		dataSource.setUrl("jdbc:sqlite:" + dbPath.toAbsolutePath());
+		return new JdbcTemplate(dataSource);
+	}
+}

--- a/src/test/java/com/logcopilot/persistence/SqlitePersistenceTest.java
+++ b/src/test/java/com/logcopilot/persistence/SqlitePersistenceTest.java
@@ -1,0 +1,206 @@
+package com.logcopilot.persistence;
+
+import com.logcopilot.LogcopilotApplication;
+import com.logcopilot.alert.AlertService;
+import com.logcopilot.common.persistence.PersistenceProperties;
+import com.logcopilot.common.persistence.TokenHashStore;
+import com.logcopilot.connector.LokiConnectorService;
+import com.logcopilot.connector.LokiPullCursorStore;
+import com.logcopilot.ingest.domain.CanonicalLogEvent;
+import com.logcopilot.incident.IncidentService;
+import com.logcopilot.llm.LlmAccountService;
+import com.logcopilot.llm.LlmOAuthProperties;
+import com.logcopilot.policy.PolicyService;
+import com.logcopilot.project.ProjectDto;
+import com.logcopilot.project.ProjectService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqlitePersistenceTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void restoresCoreStateAcrossRestart() {
+		Path dbPath = tempDir.resolve("logcopilot-t21-restart.sqlite");
+		deleteIfExists(dbPath);
+		String projectId;
+
+		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+			ProjectService projectService = context.getBean(ProjectService.class);
+			LokiConnectorService connectorService = context.getBean(LokiConnectorService.class);
+			LlmAccountService llmAccountService = context.getBean(LlmAccountService.class);
+			PolicyService policyService = context.getBean(PolicyService.class);
+			AlertService alertService = context.getBean(AlertService.class);
+			IncidentService incidentService = context.getBean(IncidentService.class);
+			LokiPullCursorStore cursorStore = context.getBean(LokiPullCursorStore.class);
+
+			ProjectDto project = projectService.create("t21-persist-project-" + UUID.randomUUID(), "prod");
+			projectId = project.id();
+
+			connectorService.upsert(projectId, new LokiConnectorService.LokiConnectorRequest(
+				"https://loki.example.com",
+				"tenant-a",
+				new LokiConnectorService.AuthRequest("bearer", "loki-secret-token", null, null),
+				"{service=\"api\"}",
+				30
+			));
+			llmAccountService.upsertApiKey(projectId, new LlmAccountService.ApiKeyUpsertCommand(
+				"openai",
+				"main",
+				"sk-secret-api-key",
+				"gpt-4o-mini",
+				"https://api.openai.com/v1"
+			));
+			policyService.updateRedactionPolicy(projectId, new PolicyService.RedactionPolicyCommand(
+				true,
+				List.of(
+					new PolicyService.RedactionRuleCommand("token", "token=[^\\s]+", "token=[REDACTED]"),
+					new PolicyService.RedactionRuleCommand("password", "password=[^\\s]+", "password=[REDACTED]"),
+					new PolicyService.RedactionRuleCommand("secret", "secret=[^\\s]+", "secret=[REDACTED]")
+				)
+			));
+			alertService.configureEmail(projectId, "actor-a", new AlertService.ConfigureEmailCommand(
+				"alerts@example.com",
+				List.of("oncall@example.com"),
+				new AlertService.SmtpCommand("smtp.example.com", 587, "mailer", "smtp-secret-password", true),
+				0.5
+			));
+			incidentService.recordIngestedEvents(projectId, List.of(sampleEvent("evt-1")));
+			cursorStore.commit(projectId, 42L);
+		}
+
+		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+			ProjectService projectService = context.getBean(ProjectService.class);
+			LokiConnectorService connectorService = context.getBean(LokiConnectorService.class);
+			LlmAccountService llmAccountService = context.getBean(LlmAccountService.class);
+			PolicyService policyService = context.getBean(PolicyService.class);
+			AlertService alertService = context.getBean(AlertService.class);
+			IncidentService incidentService = context.getBean(IncidentService.class);
+			LokiPullCursorStore cursorStore = context.getBean(LokiPullCursorStore.class);
+
+			assertThat(projectService.existsById(projectId)).isTrue();
+			assertThat(connectorService.findByProjectId(projectId)).isPresent();
+			List<LlmAccountService.LlmAccount> llmAccounts = llmAccountService.list(projectId);
+			assertThat(llmAccounts).hasSize(1);
+			assertThat(llmAccounts.get(0).provider()).isEqualTo("openai");
+			assertThat(policyService.redactForLlm(projectId, "token=abc password=pw secret=sec"))
+				.isEqualTo("token=[REDACTED] password=[REDACTED] secret=[REDACTED]");
+			assertThat(alertService.listAuditLogs(projectId, new AlertService.AuditLogQuery(null, null, null, 50)).data())
+				.isNotEmpty();
+			assertThat(incidentService.list(projectId, null, null, null, 50).data()).isNotEmpty();
+			assertThat(cursorStore.readCursor(projectId)).isEqualTo(42L);
+		}
+	}
+
+	@Test
+	void storesSecretsEncryptedAndIngestTokensAsHashes() throws Exception {
+		Path dbPath = tempDir.resolve("logcopilot-t21-secret.sqlite");
+		deleteIfExists(dbPath);
+		String projectId;
+		Path[] effectiveDbPath = new Path[] { dbPath };
+
+		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+			ProjectService projectService = context.getBean(ProjectService.class);
+			LokiConnectorService connectorService = context.getBean(LokiConnectorService.class);
+			LlmAccountService llmAccountService = context.getBean(LlmAccountService.class);
+			AlertService alertService = context.getBean(AlertService.class);
+			TokenHashStore tokenHashStore = context.getBean(TokenHashStore.class);
+			PersistenceProperties persistenceProperties = context.getBean(PersistenceProperties.class);
+			effectiveDbPath[0] = resolveSqlitePath(persistenceProperties.getSqlitePath());
+
+			ProjectDto project = projectService.create("t21-secret-project-" + UUID.randomUUID(), "prod");
+			projectId = project.id();
+
+			connectorService.upsert(projectId, new LokiConnectorService.LokiConnectorRequest(
+				"https://loki.example.com",
+				"tenant-a",
+				new LokiConnectorService.AuthRequest("basic", null, "loki-user", "loki-secret-password"),
+				"{service=\"api\"}",
+				30
+			));
+			llmAccountService.upsertApiKey(projectId, new LlmAccountService.ApiKeyUpsertCommand(
+				"gemini",
+				"gemini-main",
+				"gsk-secret-api-key",
+				"gemini-2.0-flash",
+				null
+			));
+			alertService.configureEmail(projectId, "actor-a", new AlertService.ConfigureEmailCommand(
+				"alerts@example.com",
+				List.of("oncall@example.com"),
+				new AlertService.SmtpCommand("smtp.example.com", 587, "mailer", "smtp-secret-password", true),
+				0.5
+			));
+
+			assertThat(tokenHashStore.findTokenType("ingest-token")).contains("INGEST");
+		}
+
+		byte[] dbBytes = Files.readAllBytes(effectiveDbPath[0]);
+		assertThat(dbBytes.length).isPositive();
+		assertThat(contains(dbBytes, "loki-secret-password")).isFalse();
+		assertThat(contains(dbBytes, "gsk-secret-api-key")).isFalse();
+		assertThat(contains(dbBytes, "smtp-secret-password")).isFalse();
+		assertThat(contains(dbBytes, "ingest-token")).isFalse();
+	}
+
+	private ConfigurableApplicationContext startContext(Path dbPath) {
+		return new SpringApplicationBuilder(LogcopilotApplication.class)
+			.run(
+				"--server.port=0",
+				"--spring.task.scheduling.enabled=false",
+				"--logcopilot.persistence.enabled=true",
+				"--logcopilot.persistence.sqlite.path=" + dbPath.toAbsolutePath(),
+				"--logcopilot.persistence.encryption-key=t21-test-encryption-key",
+				"--logcopilot.llm.oauth.mode=" + LlmOAuthProperties.Mode.STUB.name().toLowerCase()
+			);
+	}
+
+	private void deleteIfExists(Path dbPath) {
+		try {
+			Files.deleteIfExists(dbPath);
+		} catch (Exception exception) {
+			throw new IllegalStateException("Failed to clean sqlite file: " + dbPath, exception);
+		}
+	}
+
+	private Path resolveSqlitePath(String configuredPath) {
+		if (configuredPath == null || configuredPath.isBlank()) {
+			return Path.of("./data/logcopilot.sqlite").toAbsolutePath();
+		}
+		String normalized = configuredPath.trim();
+		if (normalized.startsWith("jdbc:sqlite:")) {
+			normalized = normalized.substring("jdbc:sqlite:".length());
+		}
+		return Path.of(normalized).toAbsolutePath();
+	}
+
+	private CanonicalLogEvent sampleEvent(String eventId) {
+		return new CanonicalLogEvent(
+			eventId,
+			"2026-03-04T00:00:00Z",
+			"api",
+			"error",
+			"database timeout",
+			null,
+			null,
+			null,
+			null
+		);
+	}
+
+	private boolean contains(byte[] source, String plainText) {
+		return new String(source, StandardCharsets.UTF_8).contains(plainText);
+	}
+}

--- a/src/test/java/com/logcopilot/persistence/SqlitePersistenceTest.java
+++ b/src/test/java/com/logcopilot/persistence/SqlitePersistenceTest.java
@@ -35,9 +35,10 @@ class SqlitePersistenceTest {
 	void restoresCoreStateAcrossRestart() {
 		Path dbPath = tempDir.resolve("logcopilot-t21-restart.sqlite");
 		deleteIfExists(dbPath);
+		String encryptionSecret = "ephemeral-" + UUID.randomUUID();
 		String projectId;
 
-		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+		try (ConfigurableApplicationContext context = startContext(dbPath, encryptionSecret)) {
 			ProjectService projectService = context.getBean(ProjectService.class);
 			LokiConnectorService connectorService = context.getBean(LokiConnectorService.class);
 			LlmAccountService llmAccountService = context.getBean(LlmAccountService.class);
@@ -81,7 +82,7 @@ class SqlitePersistenceTest {
 			cursorStore.commit(projectId, 42L);
 		}
 
-		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+		try (ConfigurableApplicationContext context = startContext(dbPath, encryptionSecret)) {
 			ProjectService projectService = context.getBean(ProjectService.class);
 			LokiConnectorService connectorService = context.getBean(LokiConnectorService.class);
 			LlmAccountService llmAccountService = context.getBean(LlmAccountService.class);
@@ -108,10 +109,11 @@ class SqlitePersistenceTest {
 	void storesSecretsEncryptedAndIngestTokensAsHashes() throws Exception {
 		Path dbPath = tempDir.resolve("logcopilot-t21-secret.sqlite");
 		deleteIfExists(dbPath);
+		String encryptionSecret = "ephemeral-" + UUID.randomUUID();
 		String projectId;
 		Path[] effectiveDbPath = new Path[] { dbPath };
 
-		try (ConfigurableApplicationContext context = startContext(dbPath)) {
+		try (ConfigurableApplicationContext context = startContext(dbPath, encryptionSecret)) {
 			ProjectService projectService = context.getBean(ProjectService.class);
 			LokiConnectorService connectorService = context.getBean(LokiConnectorService.class);
 			LlmAccountService llmAccountService = context.getBean(LlmAccountService.class);
@@ -155,14 +157,14 @@ class SqlitePersistenceTest {
 		assertThat(contains(dbBytes, "ingest-token")).isFalse();
 	}
 
-	private ConfigurableApplicationContext startContext(Path dbPath) {
+	private ConfigurableApplicationContext startContext(Path dbPath, String encryptionSecret) {
 		return new SpringApplicationBuilder(LogcopilotApplication.class)
 			.run(
 				"--server.port=0",
 				"--spring.task.scheduling.enabled=false",
 				"--logcopilot.persistence.enabled=true",
-				"--logcopilot.persistence.sqlite.path=" + dbPath.toAbsolutePath(),
-				"--logcopilot.persistence.encryption-key=t21-test-encryption-key",
+				"--logcopilot.persistence.sqlite-path=" + dbPath.toAbsolutePath(),
+				"--logcopilot.persistence.encryption-key=" + encryptionSecret,
 				"--logcopilot.llm.oauth.mode=" + LlmOAuthProperties.Mode.STUB.name().toLowerCase()
 			);
 	}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+logcopilot.persistence.enabled=false


### PR DESCRIPTION
## 요약
- 무엇이 변경되었는가:
  - SQLite 기반 상태 스냅샷 저장/복원 계층을 도입하고, Project/LokiConnector/LlmAccount/Policy/Alert/Incident 서비스를 영속화 경로에 연결했습니다.
  - Loki pull cursor를 SQLite 저장소로 전환하고, Bearer token 검증을 hash 저장소 기반으로 보강했습니다.
  - 재시작 복원/secret 비노출/audit append-only 검증 테스트를 추가했습니다.
- 왜 필요한가:
  - T-21 요구사항(재시작 복원, secret 암호화 저장, ingest token hash 저장, audit append-only)을 충족하기 위해 필요합니다.

## 연결 이슈
- Closes #49

## 범위 점검
- 포함:
  - SQLite persistence 공통 계층 + 암호화 스냅샷 저장소
  - 서비스 상태 저장/복원 연결
  - hash 기반 토큰 저장소 및 인증 경로 보완
  - T-21 통합 테스트/세션 노트
- 제외:
  - 신규 API 엔드포인트 추가
  - SLO 측정/운영 하드닝(T-22)

## 주요 변경 사항
- 변경 1
  - `spring-jdbc`, `sqlite-jdbc` 의존성 추가
  - `common/persistence` 패키지(PersistenceProperties, SqlitePersistenceConfiguration, StateCipher, SqliteStateSnapshotRepository, SqliteTokenHashStore 등) 신설
- 변경 2
  - Project/LokiConnector/LlmAccount/Policy/Alert/Incident 서비스 상태 snapshot load/save 연결
  - `SqliteLokiPullCursorStore` 추가 및 `LokiPullCursorStore` 구현 전환
- 변경 3
  - `BearerTokenValidator`를 token-hash 저장소 조회로 확장하고 저장소 예외 시 Unauthorized 정규화
- 변경 4
  - `SqlitePersistenceTest`, `AuditPersistenceTest`, `BearerTokenValidatorTest` 보강

## TDD 근거
- RED:
  - `*SqlitePersistenceTest`, `*AuditPersistenceTest` 추가 후 복원/보호 저장 미구현 실패 확인
- GREEN:
  - SQLite snapshot/hash 저장소 및 서비스 연결 후 해당 테스트 PASS
- REFACTOR:
  - 딴지 리뷰 반영(복원 실패 시 row 자동 삭제 제거, 인증 예외 정규화, incident 복원 검증 추가)

## 검증 결과
- `./gradlew check`: PASS
- `./gradlew test`: PASS
- `./gradlew build`: PASS

## Rule-Base 근거
- AC8 -> `./gradlew test --tests "*SqlitePersistenceTest" --tests "*AuditPersistenceTest" --tests "*BearerTokenValidatorTest"` -> PASS
- AC9 -> `./gradlew check && ./gradlew test && ./gradlew build` -> PASS

## 리뷰 피드백 반영
- coderabbitai:
  - 대기
- codex:
  - Explorer 딴지 리뷰 반영 완료
    - 복원 실패 시 스냅샷 삭제 제거
    - hash 저장소 장애 시 401 정규화
    - incident 재시작 복원 검증 추가

## 리스크 / 롤백
- 확인된 리스크:
  - snapshot 저장 실패 시 일시적 메모리-디스크 불일치 가능성
  - 서비스 단위 snapshot 구조로 cross-service transaction 미보장
- 롤백 계획:
  - 본 PR revert 시 기존 in-memory 경로로 복귀
  - `logcopilot.persistence.enabled=false`로 persistence 우회 가능

## 릴리스 메모 (`develop` 머지 기준)
- 후속 작업:
  - T-22에서 SLO 증거(incident p95/analysis p95/ingest success rate) 문서화 및 최종 운영 게이트 정리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 상태가 자동으로 저장되어 재시작 후 복구됩니다 (프로젝트, 설정, 인시던트, 경고, 정책 포함).
  * 민감한 데이터가 암호화되어 저장됩니다.
  * 토큰 인증에 향상된 보안 저장소가 적용됩니다.

* **테스트**
  * 지속성 및 암호화 검증 통합 테스트 추가.

* **기타**
  * SQLite 데이터베이스 지원 추가.
  * 지속성 구성 옵션 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->